### PR TITLE
Add field! for property!

### DIFF
--- a/spec/granite_orm/fields/field_spec.cr
+++ b/spec/granite_orm/fields/field_spec.cr
@@ -1,0 +1,34 @@
+require "../../spec_helper"
+
+class Field < Granite::ORM::Base
+  adapter pg
+
+  field normal : Int32
+  field! raise_on_nil : Int32
+end
+
+describe Granite::ORM::Fields do
+  describe "field" do
+    it "generates a nilable field getter and a raise-on-nil field getter suffixed with '!'" do
+      field = Field.new(normal: 1)
+      nil_field = Field.new
+
+      field.normal.should eq(1)
+      field.normal!.should eq(1)
+      nil_field.normal.should be_nil
+      expect_raises(Exception, "Field#normal cannot be nil") { nil_field.normal! }
+    end
+  end
+
+  describe "field!" do
+    it "generates a raise-on-nil field getter and a nilable field getter suffixed with '?'" do
+      field = Field.new(raise_on_nil: 1)
+      nil_field = Field.new
+
+      field.raise_on_nil.should eq(1)
+      field.raise_on_nil?.should eq(1)
+      expect_raises(Exception, "Field#raise_on_nil cannot be nil") { nil_field.raise_on_nil }
+      nil_field.raise_on_nil?.should be_nil
+    end
+  end
+end

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -17,7 +17,8 @@ module Granite::ORM::Querying
       def set_attributes(result : DB::ResultSet)
         # Loading from DB means existing records.
         @new_record = false
-        \{% for name, type in FIELDS %}
+        \{% for name, options in FIELDS %}
+          \{% type = options[:type] %}
           \{% if type.id.stringify == "Time" %}
             if @@adapter.class.name == "Granite::Adapter::Sqlite"
               # sqlite3 does not have timestamp type - timestamps are stored as str

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -45,13 +45,6 @@ module Granite::ORM::Table
     @@primary_name = "{{primary_name}}"
     @@primary_auto = "{{primary_auto}}"
 
-    property {{primary_name}} : Union({{primary_type.id}} | Nil)
-
-    def {{primary_name}}!
-      raise {{@type.name.stringify}} + "#" + {{primary_name.stringify}} + " cannot be nil" if @{{primary_name}}.nil?
-      @{{primary_name}}.not_nil!
-    end
-
     def self.table_name
       @@table_name
     end


### PR DESCRIPTION
relate: #57, #120, #144, #171

This PR supports the two syntaxes in #171 by #57.

For example:

```crystal
class Foo < Granite::ORM::Base
  # ...
  field number : Int32
end

foo = Foo.new(number: 0)
foo.number += 1
```

This gives:

```
Error in src/test.cr:7: undefined method '+' for Nil (compile-time type is (Int32 | Nil))

foo.number += 1
^

Rerun with --error-trace to show a complete error trace.
```

It is still annoying to use `foo.number = foo.number! + 1`.

With this PR:

```crystal
class Foo < Granite::ORM::Base
  # ...
  field! number : Int32
end

foo = Foo.new(number: 0)
foo.number += 1 # It works!
```

This PR also includes the change from `type` to `options` in #120 because it is easier to implement `field!` with this feature.
This PR also removes the property in `table.cr` because it is duplicated.