### PR TITLE
Some enhancements about callbacks

### DIFF
--- a/spec/granite_orm/callbacks/abort_spec.cr
+++ b/spec/granite_orm/callbacks/abort_spec.cr
@@ -1,0 +1,133 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} #abort!" do
+    context "when create" do
+      it "doesn't run other callbacks if abort at before_save" do
+        cwa = CallbackWithAbort.new(abort_at: "before_save", do_abort: true)
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at before_save."])
+        cwa.history.to_s.strip.should eq("")
+        CallbackWithAbort.find("before_save").should be_nil
+      end
+
+      it "only runs before_save if abort at before_create" do
+        cwa = CallbackWithAbort.new(abort_at: "before_create", do_abort: true)
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at before_create."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          RUNS
+        CallbackWithAbort.find("before_create").should be_nil
+      end
+
+      it "runs before_save, before_create and save successfully if abort at after_create" do
+        cwa = CallbackWithAbort.new(abort_at: "after_create", do_abort: true)
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at after_create."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          before_create
+          RUNS
+        CallbackWithAbort.find("after_create").should be_a(CallbackWithAbort)
+      end
+
+      it "runs before_save, before_create, after_create and save successfully if abort at after_save" do
+        cwa = CallbackWithAbort.new(abort_at: "after_save", do_abort: true)
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at after_save."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          before_create
+          after_create
+          RUNS
+        CallbackWithAbort.find("after_save").should be_a(CallbackWithAbort)
+      end
+    end
+
+    context "when update" do
+      it "doesn't run other callbacks if abort at before_save" do
+        CallbackWithAbort.new(abort_at: "before_save", do_abort: false).save
+        cwa = CallbackWithAbort.find!("before_save")
+        cwa.do_abort = true
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at before_save."])
+        cwa.history.to_s.strip.should eq("")
+        CallbackWithAbort.find!("before_save").do_abort.should be_false
+      end
+
+      it "only runs before_save if abort at before_update" do
+        CallbackWithAbort.new(abort_at: "before_update", do_abort: false).save
+        cwa = CallbackWithAbort.find!("before_update")
+        cwa.do_abort = true
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at before_update."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          RUNS
+        CallbackWithAbort.find!("before_update").do_abort.should be_false
+      end
+
+      it "runs before_save, before_update and save successfully if abort at after_update" do
+        CallbackWithAbort.new(abort_at: "after_update", do_abort: false).save
+        cwa = CallbackWithAbort.find!("after_update")
+        cwa.do_abort = true
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at after_update."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          before_update
+          RUNS
+        CallbackWithAbort.find!("after_update").do_abort.should be_true
+      end
+
+      it "runs before_save, before_update, after_update and save successfully if abort at after_save" do
+        CallbackWithAbort.new(abort_at: "after_save", do_abort: false).save
+        cwa = CallbackWithAbort.find!("after_save")
+        cwa.do_abort = true
+        cwa.save
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at after_save."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_save
+          before_update
+          after_update
+          RUNS
+        CallbackWithAbort.find!("after_save").do_abort.should be_true
+      end
+    end
+
+    context "when destroy" do
+      it "doesn't run other callbacks if abort at before_destroy" do
+        CallbackWithAbort.new(abort_at: "before_destroy", do_abort: true).save
+        cwa = CallbackWithAbort.find!("before_destroy")
+        cwa.destroy
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at before_destroy."])
+        cwa.history.to_s.strip.should eq("")
+        CallbackWithAbort.find("before_destroy").should be_a(CallbackWithAbort)
+      end
+
+      it "runs before_destroy and destroy successfully if abort at after_destory" do
+        CallbackWithAbort.new(abort_at: "after_destroy", do_abort: true).save
+        cwa = CallbackWithAbort.find!("after_destroy")
+        cwa.destroy
+
+        cwa.errors.map(&.to_s).should eq(["Aborted at after_destroy."])
+        cwa.history.to_s.strip.should eq <<-RUNS
+          before_destroy
+          RUNS
+        CallbackWithAbort.find("after_destroy").should be_nil
+      end
+    end
+  end
+end
+{% end %}

--- a/src/granite_orm/callbacks.cr
+++ b/src/granite_orm/callbacks.cr
@@ -1,5 +1,10 @@
 module Granite::ORM::Callbacks
+  class Abort < Exception
+  end
+
   CALLBACK_NAMES = %i(before_save after_save before_create after_create before_update after_update before_destroy after_destroy)
+
+  @_current_callback : Symbol?
 
   macro included
     macro inherited
@@ -17,9 +22,14 @@ module Granite::ORM::Callbacks
     end
 
     macro __run_{{name.id}}
+      @_current_callback = {{name}}
       \{% for callback in CALLBACKS[{{name}}] %}
          \{{callback}}
       \{% end %}
     end
   {% end %}
+
+  def abort!(message = "Aborted at #{@_current_callback}.")
+    raise Abort.new(message)
+  end
 end

--- a/src/granite_orm/callbacks.cr
+++ b/src/granite_orm/callbacks.cr
@@ -17,16 +17,25 @@ module Granite::ORM::Callbacks
   end
 
   {% for name in CALLBACK_NAMES %}
-    macro {{name.id}}(*callbacks)
+    macro {{name.id}}(*callbacks, &block)
       \{% for callback in callbacks %}
-        \{% CALLBACKS[{{name}}] << callback.id %}
+        \{% CALLBACKS[{{name}}] << callback %}
+      \{% end %}
+      \{% if block.is_a? Block %}
+        \{% CALLBACKS[{{name}}] << block %}
       \{% end %}
     end
 
     macro __run_{{name.id}}
       @_current_callback = {{name}}
       \{% for callback in CALLBACKS[{{name}}] %}
-         \{{callback}}
+        \{% if callback.is_a? Block %}
+           begin
+             \{{callback.body}}
+           end
+        \{% else %}
+          \{{callback.id}}
+        \{% end %}
       \{% end %}
     end
   {% end %}

--- a/src/granite_orm/callbacks.cr
+++ b/src/granite_orm/callbacks.cr
@@ -17,8 +17,10 @@ module Granite::ORM::Callbacks
   end
 
   {% for name in CALLBACK_NAMES %}
-    macro {{name.id}}(callback)
-      \{% CALLBACKS[{{name}}] << callback.id %}
+    macro {{name.id}}(*callbacks)
+      \{% for callback in callbacks %}
+        \{% CALLBACKS[{{name}}] << callback.id %}
+      \{% end %}
     end
 
     macro __run_{{name.id}}

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -59,9 +59,9 @@ module Granite::ORM::Transactions
           rescue err
             raise DB::Error.new(err.message)
           end
+          @new_record = false
           __run_after_create
         end
-        @new_record = false
         __run_after_save
         return true
       rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
@@ -78,8 +78,8 @@ module Granite::ORM::Transactions
       begin
         __run_before_destroy
         @@adapter.delete(@@table_name, @@primary_name, {{primary_name}})
-        __run_after_destroy
         @destroyed = true
+        __run_after_destroy
         return true
       rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
@@ -102,17 +102,6 @@ module Granite::ORM::Transactions
       instance.save
       instance
     end
-  end
-
-  # Returns true if this object hasn't been saved yet.
-  getter? new_record : Bool = true
-
-  # Returns true if this object has been destroyed.
-  getter? destroyed : Bool = false
-
-  # Returns true if the record is persisted.
-  def persisted?
-    !(new_record? || destroyed?)
   end
 
   # Returns true if this object hasn't been saved yet.

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -64,7 +64,7 @@ module Granite::ORM::Transactions
         @new_record = false
         __run_after_save
         return true
-      rescue ex : DB::Error
+      rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
           Granite::ORM.settings.logger.error "Save Exception: #{message}"
           errors << Granite::ORM::Error.new(:base, message)
@@ -81,7 +81,7 @@ module Granite::ORM::Transactions
         __run_after_destroy
         @destroyed = true
         return true
-      rescue ex : DB::Error
+      rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
           Granite::ORM.settings.logger.error "Destroy Exception: #{message}"
           errors << Granite::ORM::Error.new(:base, message)


### PR DESCRIPTION
#### Add #abort!

A long time ago(maybe a few months), someone asked me how to abort a transaction within a callback in Amber's Gitter.
I did say that you can't, but now the feature is implemented.

Example:

```crystal
class Foo < Granite::ORM::Base
  # ...
  
  before_create do
    abort! if some_condition
  end
end
```

#### Allow multiple callbacks in one line

I don't know why I missed this in my previous PR #56.

Example:

```crystal
class Foo < Granite::ORM::Base
  # ...

  before_save method_a, method_b

  # definition of #method_a and #method_b
end
```

#### Support passing block to be a callback

This is convenient when the callback is simple.

The first example is also an example of this.

#### Move the updates of `@new_record` and `@destroyed` to proper places

Because `#abort!` in `after_create` or `after_destroy` doesn't abort the main transaction, but it would abort the update of `@new_record` and `@destroyed` before.
