### PR TITLE
Use most recent version in granite docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.24.1
+FROM crystallang/crystal:0.24.2
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev libsqlite3-dev libmysqlclient-dev
 


### PR DESCRIPTION
Updates Dockerfile to use crystal `0.24.2`