### PR TITLE
Fix Bulk Imports

### DIFF
--- a/spec/granite_orm/transactions/import_spec.cr
+++ b/spec/granite_orm/transactions/import_spec.cr
@@ -3,69 +3,186 @@ require "../../spec_helper"
 {% for adapter in GraniteExample::ADAPTERS %}
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} .import" do
-    it "should import 3 new objects" do
-      to_import = [
-        Parent.new(name: "ImportParent1"),
-        Parent.new(name: "ImportParent2"),
-        Parent.new(name: "ImportParent3"),
-      ]
-      Parent.import(to_import)
-      Parent.all("WHERE name LIKE ?", ["Import%"]).size.should eq 3
-    end
+    describe "using the defualt primary key" do
+      context "with an AUTO INCREMENT PK" do
+        it "should import 3 new objects" do
+          to_import = [
+            Parent.new(name: "ImportParent1"),
+            Parent.new(name: "ImportParent2"),
+            Parent.new(name: "ImportParent3"),
+          ]
+          Parent.import(to_import)
+          Parent.all("WHERE name LIKE ?", ["ImportParent%"]).size.should eq 3
+        end
 
-    it "should work with on_duplicate_key_update" do
-      to_import = [
-         Parent.new(id: 111, name: "ImportParent1"),
-         Parent.new(id: 112, name: "ImportParent2"),
-         Parent.new(id: 113, name: "ImportParent3"),
-      ]
+        it "should work with batch_size" do
+          to_import = [
+             Book.new(name: "ImportBatchBook1"),
+             Book.new(name: "ImportBatchBook2"),
+             Book.new(name: "ImportBatchBook3"),
+             Book.new(name: "ImportBatchBook4"),
+          ]
 
-      Parent.import(to_import)
+          Book.import(to_import, batch_size: 2)
+          Book.all("WHERE name LIKE ?", ["ImportBatch%"]).size.should eq 4
+        end
 
-      to_import = [
-         Parent.new(id: 112, name: "ImportParent112"),
-      ]
+        it "should be able to update existing records" do
+          to_import = [
+             Review.new(name: "ImportReview1", published: false, upvotes: 0.to_i64),
+             Review.new(name: "ImportReview2", published: false, upvotes: 0.to_i64),
+             Review.new(name: "ImportReview3", published: false, upvotes: 0.to_i64),
+             Review.new(name: "ImportReview4", published: false, upvotes: 0.to_i64),
+          ]
 
-      Parent.import(to_import, update_on_duplicate: true, columns: ["name"])
+          Review.import(to_import)
 
-      if parent = Parent.find 112
-        parent.name.should be "ImportParent112"
-        parent.id.should eq 112
+          reviews = Review.all("WHERE name LIKE ?", ["ImportReview%"])
+          reviews.size.should eq 4
+          reviews.none? { |r| r.published }.should be_true
+          reviews.all? { |r| r.upvotes == 0 }.should be_true
+
+          reviews.each { |r| r.published = true; r.upvotes = 1.to_i64 }
+
+          Review.import(reviews, update_on_duplicate: true, columns: ["published", "upvotes"])
+
+          reviews = Review.all("WHERE name LIKE ?", ["ImportReview%"])
+
+          reviews.size.should eq 4
+          reviews.all? { |r| r.published }.should be_true
+          reviews.all? { |r| r.upvotes == 1 }.should be_true
+        end
+      end
+      context "with non AUTO INCREMENT PK" do
+        it "should work with on_duplicate_key_update" do
+          to_import = [
+            NonAutoDefaultPK.new(id: 1.to_i64, name: "NonAutoDefaultPK1"),
+            NonAutoDefaultPK.new(id: 2.to_i64, name: "NonAutoDefaultPK2"),
+            NonAutoDefaultPK.new(id: 3.to_i64, name: "NonAutoDefaultPK3"),
+          ]
+
+          NonAutoDefaultPK.import(to_import)
+
+          to_import = [
+             NonAutoDefaultPK.new(id: 3.to_i64, name: "NonAutoDefaultPK3"),
+          ]
+
+          NonAutoDefaultPK.import(to_import, update_on_duplicate: true, columns: ["name"])
+
+          record = NonAutoDefaultPK.find! 3.to_i64
+          record.name.should eq "NonAutoDefaultPK3"
+          record.id.should eq 3.to_i64
+        end
+
+        it "should work with on_duplicate_key_ignore" do
+          to_import = [
+            NonAutoDefaultPK.new(id: 4.to_i64, name: "NonAutoDefaultPK4"),
+            NonAutoDefaultPK.new(id: 5.to_i64, name: "NonAutoDefaultPK5"),
+            NonAutoDefaultPK.new(id: 6.to_i64, name: "NonAutoDefaultPK6"),
+          ]
+
+          NonAutoDefaultPK.import(to_import)
+
+          to_import = [
+             NonAutoDefaultPK.new(id: 6.to_i64, name: "NonAutoDefaultPK6"),
+          ]
+
+          NonAutoDefaultPK.import(to_import, ignore_on_duplicate: true)
+
+          record = NonAutoDefaultPK.find! 6.to_i64
+          record.name.should eq "NonAutoDefaultPK6"
+          record.id.should eq 6.to_i64
+        end
       end
     end
+    describe "using a custom primary key" do
+      context "with an AUTO INCREMENT PK" do
+        it "should import 3 new objects" do
+          to_import = [
+            School.new(name: "ImportBasicSchool1"),
+            School.new(name: "ImportBasicSchool2"),
+            School.new(name: "ImportBasicSchool3"),
+          ]
+          School.import(to_import)
+          School.all("WHERE name LIKE ?", ["ImportBasicSchool%"]).size.should eq 3
+        end
 
-    it "should work with on_duplicate_key_ignore" do
-      to_import = [
-         Parent.new(id: 111, name: "ImportParent1"),
-         Parent.new(id: 112, name: "ImportParent2"),
-         Parent.new(id: 113, name: "ImportParent3"),
-      ]
+        it "should work with batch_size" do
+          to_import = [
+             School.new(name: "ImportBatchSchool1"),
+             School.new(name: "ImportBatchSchool2"),
+             School.new(name: "ImportBatchSchool3"),
+             School.new(name: "ImportBatchSchool4"),
+          ]
 
-      Parent.import(to_import)
+          School.import(to_import, batch_size: 2)
+          School.all("WHERE name LIKE ?", ["ImportBatchSchool%"]).size.should eq 4
+        end
 
-      to_import = [
-         Parent.new(id: 113, name: "ImportParent113"),
-      ]
+        it "should be able to update existing records" do
+          to_import = [
+             School.new(name: "ImportExistingSchool"),
+             School.new(name: "ImportExistingSchool"),
+             School.new(name: "ImportExistingSchool"),
+             School.new(name: "ImportExistingSchool"),
+          ]
 
-      Parent.import(to_import, ignore_on_duplicate: true)
+          School.import(to_import)
 
-      if parent = Parent.find 113
-        parent.name.should be "ImportParent3"
-        parent.id.should eq 113
+          schools = School.all("WHERE name = ?", ["ImportExistingSchool"])
+          schools.size.should eq 4
+          schools.all? { |s| s.name == "ImportExistingSchool" }.should be_true
+
+          schools.each { |s| s.name = "ImportExistingSchoolEdited" }
+
+          School.import(schools, update_on_duplicate: true, columns: ["name"])
+
+          schools = School.all("WHERE name LIKE ?", ["ImportExistingSchool%"])
+          schools.size.should eq 4
+          schools.all? { |s| s.name == "ImportExistingSchoolEdited" }.should be_true
+        end
       end
-    end
+      context "with non AUTO INCREMENT PK" do
+        it "should work with on_duplicate_key_update" do
+          to_import = [
+            NonAutoCustomPK.new(custom_id: 1.to_i64, name: "NonAutoCustomPK1"),
+            NonAutoCustomPK.new(custom_id: 2.to_i64.to_i64, name: "NonAutoCustomPK2"),
+            NonAutoCustomPK.new(custom_id: 3.to_i64, name: "NonAutoCustomPK3"),
+          ]
 
-    it "should work with batch_size" do
-      to_import = [
-         Book.new(id: 111, name: "ImportBook1"),
-         Book.new(id: 112, name: "ImportBook2"),
-         Book.new(id: 113, name: "ImportBook3"),
-         Book.new(id: 114, name: "ImportBook4"),
-      ]
+          NonAutoCustomPK.import(to_import)
 
-      Book.import(to_import, batch_size: 2)
+          to_import = [
+             NonAutoCustomPK.new(custom_id: 3.to_i64, name: "NonAutoCustomPK3"),
+          ]
 
-      Book.all("WHERE name LIKE ?", ["Import%"]).size.should eq 4
+          NonAutoCustomPK.import(to_import, update_on_duplicate: true, columns: ["name"])
+
+          record = NonAutoCustomPK.find! 3.to_i64
+          record.name.should eq "NonAutoCustomPK3"
+          record.custom_id.should eq 3.to_i64
+        end
+
+        it "should work with on_duplicate_key_ignore" do
+          to_import = [
+            NonAutoCustomPK.new(custom_id: 4.to_i64, name: "NonAutoCustomPK4"),
+            NonAutoCustomPK.new(custom_id: 5.to_i64, name: "NonAutoCustomPK5"),
+            NonAutoCustomPK.new(custom_id: 6.to_i64, name: "NonAutoCustomPK6"),
+          ]
+
+          NonAutoCustomPK.import(to_import)
+
+          to_import = [
+             NonAutoCustomPK.new(custom_id: 6.to_i64, name: "NonAutoCustomPK6"),
+          ]
+
+          NonAutoCustomPK.import(to_import, ignore_on_duplicate: true)
+
+          record = NonAutoCustomPK.find! 6.to_i64
+          record.name.should eq "NonAutoCustomPK6"
+          record.custom_id.should eq 6.to_i64
+        end
+      end
     end
   end
 end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -11,6 +11,7 @@ require "uuid"
 
     if adapter == "pg"
       primary_key_sql = "BIGSERIAL PRIMARY KEY".id
+      primary_key_non_auto_increment_sql = "BIGINT PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
       custom_primary_key_sql = "SERIAL PRIMARY KEY".id
       custom_foreign_key_sql = "INT".id
@@ -19,6 +20,7 @@ require "uuid"
       timestamp_fields = "timestamps".id
     elsif adapter == "mysql"
       primary_key_sql = "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
+      primary_key_non_auto_increment_sql = "BIGINT NOT NULL PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
       custom_primary_key_sql = "INT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
       custom_foreign_key_sql = "INT".id
@@ -27,6 +29,7 @@ require "uuid"
       timestamp_fields = "timestamps".id
     elsif adapter == "sqlite"
       primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
+      primary_key_non_auto_increment_sql = "INTEGER NOT NULL PRIMARY KEY".id
       foreign_key_sql = "INTEGER".id
       custom_primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
       custom_foreign_key_sql = "INTEGER".id
@@ -414,6 +417,42 @@ require "uuid"
     end
   end
 
+  class NonAutoDefaultPK < Granite::ORM::Base
+    adapter {{ adapter_literal }}
+    table_name non_auto_default_pk
+
+    primary id : Int64, auto: false
+    field name : String
+
+    def self.drop_and_create
+      exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
+      exec <<-SQL
+        CREATE TABLE #{ quoted_table_name } (
+          id {{ primary_key_non_auto_increment_sql }},
+          name VARCHAR(255)
+        )
+      SQL
+    end
+  end
+
+  class NonAutoCustomPK < Granite::ORM::Base
+    adapter {{ adapter_literal }}
+    table_name non_auto_custom_pk
+
+    primary custom_id : Int64, auto: false
+    field name : String
+
+    def self.drop_and_create
+      exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
+      exec <<-SQL
+        CREATE TABLE #{ quoted_table_name } (
+          custom_id {{ primary_key_non_auto_increment_sql }},
+          name VARCHAR(255)
+        )
+      SQL
+    end
+  end
+
     Parent.drop_and_create
     Teacher.drop_and_create
     Student.drop_and_create
@@ -432,5 +471,7 @@ require "uuid"
     Book.drop_and_create
     BookReview.drop_and_create
     Item.drop_and_create
+    NonAutoDefaultPK.drop_and_create
+    NonAutoCustomPK.drop_and_create
   end
 {% end %}

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -50,7 +50,7 @@ abstract class Granite::Adapter::Base
   abstract def insert(table_name, fields, params, lastval) : Int64
 
   # This will insert an array of models as one insert statement
-  abstract def import(table_name : String, primary_name : String, fields, model_array, **options)
+  abstract def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
 
   # This will update a row in the database.
   abstract def update(table_name, primary_name, fields, params)

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -76,10 +76,9 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     end
   end
 
-  def import(table_name : String, primary_name : String, fields, model_array, **options)
+  def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
     now = Time.now.to_utc
-    fields.reject! { |field| field === "id" } if primary_name === "id"
 
     statement = String.build do |stmt|
       stmt << "INSERT"

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -76,10 +76,12 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
   end
 
-  def import(table_name : String, primary_name : String, fields, model_array, **options)
+  def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
     now = Time.now.to_utc
-    fields.reject! { |field| field === "id" } if primary_name === "id"
+    # PG fails when inserting null into AUTO INCREMENT PK field.
+    # If AUTO INCREMENT is TRUE AND all model's pk are nil, remove PK from fields list for AUTO INCREMENT to work properly
+    fields.reject! { |field| field == primary_name } if model_array.all? { |m| m.to_h[primary_name].nil? } && auto == "true"
     index = 0
 
     statement = String.build do |stmt|

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -74,10 +74,9 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
   end
 
-  def import(table_name : String, primary_name : String, fields, model_array, **options)
+  def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
     now = Time.now.to_utc
-    fields.reject! { |field| field === "id" } if primary_name === "id"
 
     statement = String.build do |stmt|
       stmt << "INSERT "

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -10,33 +10,33 @@ module Granite::ORM::Transactions
     # The import class method will run a batch INSERT statement for each model in the array
     # the array must contain only one model class
     # invalid model records will be skipped
-    def self.import(model_array : Array(self), batch_size : Int32 = model_array.size)
+    def self.import(model_array : Array(self) | Granite::ORM::Collection(self), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
-          @@adapter.import(table_name, primary_name, fields_duplicate, slice)
+          @@adapter.import(table_name, primary_name, primary_auto, fields_duplicate, slice)
         end
       rescue err
         raise DB::Error.new(err.message)
       end
     end
 
-    def self.import(model_array : Array(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
+    def self.import(model_array : Array(self) | Granite::ORM::Collection(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
-          @@adapter.import(table_name, primary_name, fields_duplicate, slice)
+          @@adapter.import(table_name, primary_name, primary_auto, fields_duplicate, slice, update_on_duplicate: update_on_duplicate, columns: columns)
         end
       rescue err
         raise DB::Error.new(err.message)
       end
     end
 
-    def self.import(model_array : Array(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
+    def self.import(model_array : Array(self) | Granite::ORM::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
-          @@adapter.import(table_name, primary_name, fields_duplicate, slice)
+          @@adapter.import(table_name, primary_name, primary_auto, fields_duplicate, slice, ignore_on_duplicate: ignore_on_duplicate)
         end
       rescue err
         raise DB::Error.new(err.message)


### PR DESCRIPTION
This PR addresses some issues i uncovered recently, removing too much when implementing the batch size, while the tests passed.

1. Re add the extra params for `ignore_on_duplicate` and `update_on_duplicate`
2. Add `Granite::ORM::Collection(self)` typing to `model_array` param so that records can be fetched from DB, iterated upon, and reimported easily.  See [This Spec](https://github.com/Blacksmoke16/granite-orm/blob/fix-bulk-import/spec/granite_orm/transactions/import_spec.cr#L40-L47)
1. Greatly expands the test suite of bulk imports to cover standard usages, `batch_size`, `ignore_on_duplicate` and `update_on_duplicate` for each of the following:
    * Non AUTO INCREMENT default name PK
    * AUTO INCREMENT default name PK
    * Non AUTO INCREMENT custom name PK
    * AUTO INCREMENT custom name PK