### PR TITLE
Fixes to Migrator provided by Maiha

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,24 @@ You can register callbacks for the following events:
 - **destroy**
 - after_destroy
 
+### Migration
+
+- `migrator` provides `drop`, `create` and `drop_and_create` methods
+
+```crystal
+class User < Granite::ORM::Base
+  adapter mysql
+  field name : String
+end
+
+User.migrator.drop_and_create
+# => "DROP TABLE IF EXISTS `users`;"
+# => "CREATE TABLE `users` (id BIGSERIAL PRIMARY KEY, name VARCHAR(255));"
+
+User.migrator(table_options: "ENGINE=InnoDB DEFAULT CHARSET=utf8").create
+# => "CREATE TABLE ... ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/amberframework/granite/fork )

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -137,16 +137,6 @@ require "uuid"
           history << "{{name.id}}\n"
         end
       {% end %}
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            abort_at VARCHAR(31),
-            do_abort BOOL
-          )
-        SQL
-      end
     end
 
     class Kvs < Granite::ORM::Base
@@ -161,16 +151,6 @@ require "uuid"
       table_name people
 
       field name : String
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            name VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Company < Granite::ORM::Base
@@ -179,16 +159,6 @@ require "uuid"
 
       primary id : Int32
       field name : String
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ custom_primary_key_sql }},
-            name VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Book < Granite::ORM::Base
@@ -236,12 +206,12 @@ require "uuid"
     Empty.migrator.drop_and_create
     ReservedWord.migrator.drop_and_create
     Callback.migrator.drop_and_create
-    CallbackWithAbort.drop_and_create
+    CallbackWithAbort.migrator.drop_and_create
     Kvs.migrator.drop_and_create
-    Person.drop_and_create
-    Company.drop_and_create
+    Person.migrator.drop_and_create
+    Company.migrator.drop_and_create
     Book.migrator.drop_and_create
     BookReview.migrator.drop_and_create
-    Item.drop_and_create
+    Item.migrator.drop_and_create
   end
 {% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -6,36 +6,7 @@ end
 require "uuid"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    adapter_literal = adapter.id
-
-    if adapter == "pg"
-      primary_key_sql = "BIGSERIAL PRIMARY KEY".id
-      foreign_key_sql = "BIGINT".id
-      custom_primary_key_sql = "SERIAL PRIMARY KEY".id
-      custom_foreign_key_sql = "INT".id
-      created_at_sql = "created_at TIMESTAMP".id
-      updated_at_sql = "updated_at TIMESTAMP".id
-      timestamp_fields = "timestamps".id
-    elsif adapter == "mysql"
-      primary_key_sql = "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
-      foreign_key_sql = "BIGINT".id
-      custom_primary_key_sql = "INT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
-      custom_foreign_key_sql = "INT".id
-      created_at_sql = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP".id
-      updated_at_sql = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP".id
-      timestamp_fields = "timestamps".id
-    elsif adapter == "sqlite"
-      primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
-      foreign_key_sql = "INTEGER".id
-      custom_primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
-      custom_foreign_key_sql = "INTEGER".id
-      created_at_sql = "created_at VARCHAR".id
-      updated_at_sql = "updated_at VARCHAR".id
-      timestamp_fields = "timestamps".id
-    end
-  %}
-
+  {% adapter_literal = adapter.id %}
   require "../src/adapter/{{ adapter_literal }}"
 
   module {{adapter.capitalize.id}}
@@ -45,23 +16,12 @@ require "uuid"
       table_name parents
 
       field name : String
-      {{ timestamp_fields }}
+      timestamps
 
       has_many :students
 
       validate :name, "Name cannot be blank" do |parent|
         !parent.name.to_s.blank?
-      end
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec("CREATE TABLE #{ quoted_table_name } (
-          id {{ primary_key_sql }},
-          name VARCHAR(100),
-          {{ created_at_sql }},
-          {{ updated_at_sql }}
-        );
-        ")
       end
     end
 
@@ -73,15 +33,6 @@ require "uuid"
       field name : String
 
       has_many :klasss
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec("CREATE TABLE #{ quoted_table_name } (
-          id {{ primary_key_sql }},
-          name VARCHAR(100)
-        );
-        ")
-      end
     end
 
     class Student < Granite::ORM::Base
@@ -93,16 +44,6 @@ require "uuid"
 
       has_many :enrollments
       has_many :klasss, through: :enrollments
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec("CREATE TABLE #{ quoted_table_name } (
-          id {{ primary_key_sql }},
-          name VARCHAR(100),
-          parent_id {{ foreign_key_sql }}
-        );
-        ")
-      end
     end
 
     class Klass < Granite::ORM::Base
@@ -115,17 +56,6 @@ require "uuid"
 
       has_many :enrollments
       has_many :students, through: :enrollments
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            name VARCHAR(255),
-            teacher_id {{ foreign_key_sql }}
-          )
-        SQL
-      end
     end
 
     class Enrollment < Granite::ORM::Base
@@ -135,17 +65,6 @@ require "uuid"
 
       belongs_to :student
       belongs_to :klass
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            student_id {{ foreign_key_sql }},
-            klass_id {{ foreign_key_sql }}
-          )
-        SQL
-      end
     end
 
     class School < Granite::ORM::Base
@@ -154,16 +73,6 @@ require "uuid"
       field name : String
 
       table_name schools
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            custom_id {{ primary_key_sql }},
-            name VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Nation::County < Granite::ORM::Base
@@ -172,16 +81,6 @@ require "uuid"
       table_name nation_countys
 
       field name : String
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            name VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Review < Granite::ORM::Base
@@ -194,53 +93,18 @@ require "uuid"
       field interest : Float64
       field published : Bool
       field created_at : Time
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            name VARCHAR(255),
-            downvotes INT,
-            upvotes BIGINT,
-            sentiment FLOAT,
-            interest REAL,
-            published BOOL,
-            {{ created_at_sql }}
-          )
-        SQL
-      end
     end
 
     class Empty < Granite::ORM::Base
       adapter {{ adapter_literal }}
       table_name emptys
       primary id : Int64
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }}
-          )
-        SQL
-      end
     end
 
     class ReservedWord < Granite::ORM::Base
       adapter {{ adapter_literal }}
       table_name "select"
       field all : String
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            #{quote("all")} VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Callback < Granite::ORM::Base
@@ -257,16 +121,6 @@ require "uuid"
           history << "{{name.id}}\n"
         end
       {% end %}
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ primary_key_sql }},
-            name VARCHAR(100) NOT NULL
-          )
-        SQL
-      end
     end
 
     class CallbackWithAbort < Granite::ORM::Base
@@ -300,16 +154,6 @@ require "uuid"
       table_name kvss
       primary k : String, auto: false
       field v : String
-
-      def self.drop_and_create
-        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            k VARCHAR(255),
-            v VARCHAR(255)
-          )
-        SQL
-      end
     end
 
     class Person < Granite::ORM::Base
@@ -356,18 +200,6 @@ require "uuid"
 
       primary id : Int32
       field name : String
-
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ custom_primary_key_sql }},
-            name VARCHAR(255),
-            author_id BIGINT,
-            publisher_id INT
-          )
-        SQL
-      end
     end
 
     class BookReview < Granite::ORM::Base
@@ -377,60 +209,39 @@ require "uuid"
 
       primary id : Int32
       field body : String
+    end
 
-      def self.drop_and_create
-        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-        exec <<-SQL
-          CREATE TABLE #{ quoted_table_name } (
-            id {{ custom_primary_key_sql }},
-            book_id {{ custom_foreign_key_sql }},
-            body VARCHAR(255)
-          )
-        SQL
+    class Item < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name items
+
+      primary item_id : String, auto: false
+      field item_name : String
+
+      before_create :generate_uuid
+
+      def generate_uuid
+        @item_id = UUID.random.to_s
       end
     end
 
-  class Item < Granite::ORM::Base
-    adapter {{ adapter_literal }}
-    table_name items
-
-    primary item_id : String, auto: false
-    field item_name : String
-
-    before_create :generate_uuid
-
-    def generate_uuid
-      @item_id = UUID.random.to_s
-    end
-
-    def self.drop_and_create
-      exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
-      exec <<-SQL
-            CREATE TABLE #{ quoted_table_name } (
-              item_id VARCHAR(255) PRIMARY KEY,
-              item_name VARCHAR(255)
-            )
-      SQL
-    end
-  end
-
-    Parent.drop_and_create
-    Teacher.drop_and_create
-    Student.drop_and_create
-    Klass.drop_and_create
-    Enrollment.drop_and_create
-    School.drop_and_create
-    Nation::County.drop_and_create
-    Review.drop_and_create
-    Empty.drop_and_create
-    ReservedWord.drop_and_create
-    Callback.drop_and_create
+    Parent.migrator.drop_and_create
+    Teacher.migrator.drop_and_create
+    Student.migrator.drop_and_create
+    Klass.migrator.drop_and_create
+    Enrollment.migrator.drop_and_create
+    School.migrator.drop_and_create
+    Nation::County.migrator.drop_and_create
+    Review.migrator.drop_and_create
+    Empty.migrator.drop_and_create
+    ReservedWord.migrator.drop_and_create
+    Callback.migrator.drop_and_create
     CallbackWithAbort.drop_and_create
-    Kvs.drop_and_create
+    Kvs.migrator.drop_and_create
     Person.drop_and_create
     Company.drop_and_create
-    Book.drop_and_create
-    BookReview.drop_and_create
+    Book.migrator.drop_and_create
+    BookReview.migrator.drop_and_create
     Item.drop_and_create
   end
 {% end %}

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -63,12 +63,29 @@ abstract class Granite::Adapter::Base
     Granite::Adapter::Base.env(url)
   end
 
+  module Schema
+    TYPES = {
+      "Bool"    => "BOOL",
+      "Float32" => "FLOAT",
+      "Float64" => "REAL",
+      "Int32"   => "INT",
+      "Int64"   => "BIGINT",
+      "String"  => "VARCHAR(255)",
+      "Time"    => "TIMESTAMP",
+    }
+  end
+
   # Use macro in order to read a constant defined in each subclasses.
   macro inherited
     # quotes table and column names
     def quote(name : String) : String
       char = QUOTING_CHAR
       char + name.gsub(char, "#{char}#{char}") + char
+    end
+
+    # converts the crystal class to database type of this adapter
+    def self.schema_type?(key : String)
+      Schema::TYPES[key]? || Granite::Adapter::Base::Schema::TYPES[key]?
     end
   end
 

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -5,6 +5,15 @@ require "mysql"
 class Granite::Adapter::Mysql < Granite::Adapter::Base
   QUOTING_CHAR = '`'
 
+  module Schema
+    TYPES = {
+      "AUTO_Int32" => "INT NOT NULL AUTO_INCREMENT PRIMARY KEY",
+      "AUTO_Int64" => "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY",
+      "created_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
+      "updated_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+    }
+  end
+  
   # Using TRUNCATE instead of DELETE so the id column resets to 0
   def clear(table_name)
     statement = "TRUNCATE #{quote(table_name)}"

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -5,6 +5,15 @@ require "pg"
 class Granite::Adapter::Pg < Granite::Adapter::Base
   QUOTING_CHAR = '"'
 
+  module Schema
+    TYPES = {
+      "AUTO_Int32" => "SERIAL PRIMARY KEY",
+      "AUTO_Int64" => "BIGSERIAL PRIMARY KEY",
+      "created_at" => "TIMESTAMP",
+      "updated_at" => "TIMESTAMP",
+    }
+  end  
+
   # remove all rows from a table and reset the counter on the id.
   def clear(table_name)
     statement = "DELETE FROM #{quote(table_name)}"

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -5,6 +5,17 @@ require "sqlite3"
 class Granite::Adapter::Sqlite < Granite::Adapter::Base
   QUOTING_CHAR = '"'
 
+  module Schema
+    TYPES = {
+      "AUTO_Int32" => "INTEGER NOT NULL PRIMARY KEY",
+      "AUTO_Int64" => "INTEGER NOT NULL PRIMARY KEY",
+      "Int32"      => "INTEGER",
+      "Int64"      => "INTEGER",
+      "created_at" => "VARCHAR",
+      "updated_at" => "VARCHAR",
+    }
+  end
+
   # remove all rows from a table and reset the counter on the id.
   def clear(table_name)
     statement = "DELETE FROM #{quote(table_name)}"

--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -8,6 +8,7 @@ require "./settings"
 require "./table"
 require "./transactions"
 require "./validators"
+require "./migrator"
 require "./version"
 
 # Granite::ORM::Base is the base class for your model objects.
@@ -18,6 +19,7 @@ class Granite::ORM::Base
   include Table
   include Transactions
   include Validators
+  include Migrator
 
   extend Querying
   extend Transactions::ClassMethods
@@ -28,6 +30,7 @@ class Granite::ORM::Base
       __process_fields
       __process_querying
       __process_transactions
+      __process_migrator
     end
   end
 

--- a/src/granite_orm/migrator.cr
+++ b/src/granite_orm/migrator.cr
@@ -22,11 +22,11 @@ module Granite::ORM::Migrator
     def initialize(klass, @table_options = "")
       @quoted_table_name = klass.quoted_table_name
     end
-    
+
     def drop_and_create
       drop
       create
-    end      
+    end
 
     def drop
     end
@@ -41,12 +41,12 @@ module Granite::ORM::Migrator
     {% primary_auto = PRIMARY[:auto] %}
     {% klass = @type.name %}
     {% adapter = "#{klass}.adapter".id %}
-    
+
     class Migrator < Granite::ORM::Migrator::Base
       def drop
         {{klass}}.exec "DROP TABLE IF EXISTS #{ @quoted_table_name };"
       end
-    
+
       def create
         resolve = ->(key : String) {
           {{adapter}}.class.schema_type?(key) || raise "Migrator(#{ {{adapter}}.class.name }) doesn't support '#{key}' yet."
@@ -61,19 +61,19 @@ module Granite::ORM::Migrator
             {% if primary_auto %}
               resolve.call("AUTO_{{primary_type.id}}")
             {% else %}
-              resolve.call("{{primary_type}}")
+              resolve.call("{{primary_type.id}}")
             {% end %}
           s.print "#{k} #{v}"
 
           # content fields
-          {% for name, type in CONTENT_FIELDS %}
+          {% for name, options in CONTENT_FIELDS %}
             s.puts ","
             k = {{adapter}}.quote("{{name}}")
             v =
               {% if name.id == "created_at" || name.id == "updated_at" %}
                 resolve.call("{{name}}")
               {% else %}
-                resolve.call("{{type}}")
+                resolve.call("{{options[:type]}}")
               {% end %}
             s.puts "#{k} #{v}"
           {% end %}
@@ -84,7 +84,7 @@ module Granite::ORM::Migrator
         {{klass}}.exec stmt
       end
     end
-    
+
     def self.migrator(**args)
       Migrator.new(self, **args)
     end

--- a/src/granite_orm/migrator.cr
+++ b/src/granite_orm/migrator.cr
@@ -1,0 +1,92 @@
+require "./error"
+
+# DB migration tool that prepares a table for the class
+#
+# ```crystal
+# class User < Granite::ORM::Base
+#   adapter mysql
+#   field name : String
+# end
+#
+# User.migrator.drop_and_create
+# # => "DROP TABLE IF EXISTS `users`;"
+# # => "CREATE TABLE `users` (id BIGSERIAL PRIMARY KEY, name VARCHAR(255));"
+#
+# User.migrator(table_options: "ENGINE=InnoDB DEFAULT CHARSET=utf8").create
+# # => "CREATE TABLE ... ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+# ```
+module Granite::ORM::Migrator
+  class Base
+    @quoted_table_name : String
+
+    def initialize(klass, @table_options = "")
+      @quoted_table_name = klass.quoted_table_name
+    end
+    
+    def drop_and_create
+      drop
+      create
+    end      
+
+    def drop
+    end
+
+    def create
+    end
+  end
+
+  macro __process_migrator
+    {% primary_name = PRIMARY[:name] %}
+    {% primary_type = PRIMARY[:type] %}
+    {% primary_auto = PRIMARY[:auto] %}
+    {% klass = @type.name %}
+    {% adapter = "#{klass}.adapter".id %}
+    
+    class Migrator < Granite::ORM::Migrator::Base
+      def drop
+        {{klass}}.exec "DROP TABLE IF EXISTS #{ @quoted_table_name };"
+      end
+    
+      def create
+        resolve = ->(key : String) {
+          {{adapter}}.class.schema_type?(key) || raise "Migrator(#{ {{adapter}}.class.name }) doesn't support '#{key}' yet."
+        }
+
+        stmt = String.build do |s|
+          s.puts "CREATE TABLE #{ @quoted_table_name }("
+
+          # primary key
+          k = {{adapter}}.quote("{{primary_name}}")
+          v =
+            {% if primary_auto %}
+              resolve.call("AUTO_{{primary_type.id}}")
+            {% else %}
+              resolve.call("{{primary_type}}")
+            {% end %}
+          s.print "#{k} #{v}"
+
+          # content fields
+          {% for name, type in CONTENT_FIELDS %}
+            s.puts ","
+            k = {{adapter}}.quote("{{name}}")
+            v =
+              {% if name.id == "created_at" || name.id == "updated_at" %}
+                resolve.call("{{name}}")
+              {% else %}
+                resolve.call("{{type}}")
+              {% end %}
+            s.puts "#{k} #{v}"
+          {% end %}
+
+          s.puts ") #{@table_options};"
+        end
+
+        {{klass}}.exec stmt
+      end
+    end
+    
+    def self.migrator(**args)
+      Migrator.new(self, **args)
+    end
+  end
+end


### PR DESCRIPTION
Dry up codes about creating tables in specs, and put it production code as `Granite::ORM.migrator`.
This helps users
- to add tables in specs easily
- to create tables in experiment and deployment

```crystal
class User < Granite::ORM::Base
  adapter mysql
  field name : String
end

User.migrator.create
```

```
mysql> describe users;
+-------+--------------+------+-----+---------+----------------+
| Field | Type         | Null | Key | Default | Extra          |
+-------+--------------+------+-----+---------+----------------+
| id    | bigint(20)   | NO   | PRI | NULL    | auto_increment |
| name  | varchar(255) | YES  |     | NULL    |                |
+-------+--------------+------+-----+---------+----------------+
```

#### implementation
- mapping rules from **crystal class** to **database type** is defined in adapters.
  - `Granite::Adapter::Base::Schema::Types`
  - `Granite::Adapter::Mysql::Schema::Types`
  - ...

I just defined rules about basic classes used in current specs.
- `Bool`, `Float32`, `Float64`, `Int32`, `Int64`, `String`, `Time`

If `migrator` is exected with undefined types, it raises a runtime error as below.

```
Migrator(Granite::Adapter::Mysql) doesn't support 'Time::Span' yet. (Exception)
```

Best regards,