### PR TITLE
remove extra abstraction and _run_

### DIFF
--- a/src/granite_orm/callbacks.cr
+++ b/src/granite_orm/callbacks.cr
@@ -15,7 +15,7 @@ module Granite::ORM::Callbacks
       }
       {% for name in CALLBACK_NAMES %}
         def {{name.id}}
-          __run_{{name.id}}
+          __{{name.id}}
         end
       {% end %}
     end
@@ -31,7 +31,7 @@ module Granite::ORM::Callbacks
       \{% end %}
     end
 
-    macro __run_{{name.id}}
+    macro __{{name.id}}
       @_current_callback = {{name}}
       \{% for callback in CALLBACKS[{{name}}] %}
         \{% if callback.is_a? Block %}

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -112,19 +112,17 @@ module Granite::ORM::Transactions
       return false unless valid?
 
       begin
+        __before_save
         if @{{primary_name}} && !new_record?
-          __before_save
           __before_update
           __update
           __after_update
-          __after_save
         else
-          __before_save
           __before_create
           __create
           __after_create
-          __after_save
         end
+        __after_save
       rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
           Granite::ORM.settings.logger.error "Save Exception: #{message}"

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -56,7 +56,7 @@ module Granite::ORM::Transactions
       end
     end
 
-    private def __run_create
+    private def __create
       @created_at = @updated_at = Time.now.to_utc
       fields = self.class.content_fields.dup
       params = content_values
@@ -88,7 +88,7 @@ module Granite::ORM::Transactions
       @new_record = false
     end
 
-    private def __run_update
+    private def __update
       @updated_at = Time.now.to_utc
       fields = self.class.content_fields
       params = content_values + [@{{primary_name}}]
@@ -100,31 +100,9 @@ module Granite::ORM::Transactions
       end
     end
 
-    private def __run_destroy
+    private def __destroy
       @@adapter.delete(@@table_name, @@primary_name, @{{primary_name}})
       @destroyed = true
-    end
-
-    private def __create
-      __run_before_save
-      __run_before_create
-      __run_create
-      __run_after_create
-      __run_after_save
-    end
-
-    private def __update
-      __run_before_save
-      __run_before_update
-      __run_update
-      __run_after_update
-      __run_after_save
-    end
-
-    private def __destroy
-      __run_before_destroy
-      __run_destroy
-      __run_after_destroy
     end
 
     # The save method will check to see if the primary exists yet. If it does it
@@ -135,9 +113,17 @@ module Granite::ORM::Transactions
 
       begin
         if @{{primary_name}} && !new_record?
+          __before_save
+          __before_update
           __update
+          __after_update
+          __after_save
         else
+          __before_save
+          __before_create
           __create
+          __after_create
+          __after_save
         end
       rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
@@ -152,7 +138,9 @@ module Granite::ORM::Transactions
     # Destroy will remove this from the database.
     def destroy
       begin
+        __before_destroy
         __destroy
+        __after_destroy
       rescue ex : DB::Error | Granite::ORM::Callbacks::Abort
         if message = ex.message
           Granite::ORM.settings.logger.error "Destroy Exception: #{message}"


### PR DESCRIPTION
This removes one level of abstraction and removes the `_run_` from the macros.