### PR TITLE
move primary key out of schema types

### DIFF
--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -7,13 +7,13 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
 
   module Schema
     TYPES = {
-      "AUTO_Int32" => "INT NOT NULL AUTO_INCREMENT PRIMARY KEY",
-      "AUTO_Int64" => "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY",
+      "AUTO_Int32" => "INT NOT NULL AUTO_INCREMENT",
+      "AUTO_Int64" => "BIGINT NOT NULL AUTO_INCREMENT",
       "created_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
       "updated_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
     }
   end
-  
+
   # Using TRUNCATE instead of DELETE so the id column resets to 0
   def clear(table_name)
     statement = "TRUNCATE #{quote(table_name)}"

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -7,12 +7,12 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
 
   module Schema
     TYPES = {
-      "AUTO_Int32" => "SERIAL PRIMARY KEY",
-      "AUTO_Int64" => "BIGSERIAL PRIMARY KEY",
+      "AUTO_Int32" => "SERIAL",
+      "AUTO_Int64" => "BIGSERIAL",
       "created_at" => "TIMESTAMP",
       "updated_at" => "TIMESTAMP",
     }
-  end  
+  end
 
   # remove all rows from a table and reset the counter on the id.
   def clear(table_name)

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -7,8 +7,8 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
   module Schema
     TYPES = {
-      "AUTO_Int32" => "INTEGER NOT NULL PRIMARY KEY",
-      "AUTO_Int64" => "INTEGER NOT NULL PRIMARY KEY",
+      "AUTO_Int32" => "INTEGER NOT NULL",
+      "AUTO_Int64" => "INTEGER NOT NULL",
       "Int32"      => "INTEGER",
       "Int64"      => "INTEGER",
       "created_at" => "VARCHAR",

--- a/src/granite_orm/migrator.cr
+++ b/src/granite_orm/migrator.cr
@@ -63,7 +63,7 @@ module Granite::ORM::Migrator
             {% else %}
               resolve.call("{{primary_type.id}}")
             {% end %}
-          s.print "#{k} #{v}"
+          s.print "#{k} #{v} PRIMARY KEY"
 
           # content fields
           {% for name, options in CONTENT_FIELDS %}


### PR DESCRIPTION
This removes the PRIMARY KEY declaration out of the type and into the macro.  This allows for fields that are not auto-incremental to still be a Primary Key and for non Primary Keys to be incremental.