### PR TITLE
Allow `find_by` to accept multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,13 @@ post = Post.find! 1 # raises when no records found
 #### Find By
 
 ```crystal
-post = Post.find_by :slug, "example_slug"
+post = Post.find_by(slug: "example_slug")
 if post
   puts post.name
 end
 
-post = Post.find_by! :slug, "foo" # raises when no records found
+post = Post.find_by!(slug: "foo") # raises when no records found.
+other_post = Post.find_by(slug: "foo", type: "bar") # Also works for multiple arguments.
 ```
 
 #### Insert

--- a/spec/granite/associations/has_many_spec.cr
+++ b/spec/granite/associations/has_many_spec.cr
@@ -70,7 +70,7 @@ module {{adapter.capitalize.id}}
         klass3.teacher = teacher
         klass3.save
 
-        klass = teacher.klasss.find_by(:name, "Test class with different name").not_nil!
+        klass = teacher.klasss.find_by(name: "Test class with different name").not_nil!
         klass.id.should eq klass3.id
         klass.name.should eq "Test class with different name"
       end
@@ -95,15 +95,15 @@ module {{adapter.capitalize.id}}
         klass3.teacher = teacher
         klass3.save
 
-        klass = teacher.klasss.find_by!(:name, "Test class with different name").not_nil!
+        klass = teacher.klasss.find_by!(name: "Test class with different name").not_nil!
         klass.id.should eq klass3.id
         klass.name.should eq "Test class with different name"
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with name=not_found"
+          "Couldn't find #{Klass.name} with name = not_found"
         ) do
-          klass = teacher.klasss.find_by!(:name, "not_found")
+          klass = teacher.klasss.find_by!(name: "not_found")
         end
       end
 
@@ -161,7 +161,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with id=#{id}"
+          "Couldn't find #{Klass.name} with id = #{id}"
         ) do
           teacher.klasss.find!(id)
         end

--- a/spec/granite/associations/has_many_spec.cr
+++ b/spec/granite/associations/has_many_spec.cr
@@ -101,7 +101,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with name = not_found"
+          "No #{Klass.name} found where name = not_found"
         ) do
           klass = teacher.klasss.find_by!(name: "not_found")
         end
@@ -161,7 +161,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with id = #{id}"
+          "No #{Klass.name} found where id = #{id}"
         ) do
           teacher.klasss.find!(id)
         end

--- a/spec/granite/associations/has_many_through_spec.cr
+++ b/spec/granite/associations/has_many_through_spec.cr
@@ -126,7 +126,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with name = not_found"
+          "No #{Klass.name} found where name = not_found"
         ) do
           klass = student.klasss.find_by!(name: "not_found")
         end
@@ -189,7 +189,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with id = #{id}"
+          "No #{Klass.name} found where id = #{id}"
         ) do
           student.klasss.find!(id)
         end

--- a/spec/granite/associations/has_many_through_spec.cr
+++ b/spec/granite/associations/has_many_through_spec.cr
@@ -93,7 +93,7 @@ module {{adapter.capitalize.id}}
         enrollment3.student = student
         enrollment3.save
 
-        klass = student.klasss.find_by(:name, "Test class with different name").not_nil!
+        klass = student.klasss.find_by(name: "Test class with different name").not_nil!
         klass.id.should eq klass3.id
         klass.name.should eq "Test class with different name"
       end
@@ -120,15 +120,15 @@ module {{adapter.capitalize.id}}
         enrollment3.student = student
         enrollment3.save
 
-        klass = student.klasss.find_by!(:name, "Test class with different name").not_nil!
+        klass = student.klasss.find_by!(name: "Test class with different name").not_nil!
         klass.id.should eq klass3.id
         klass.name.should eq "Test class with different name"
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with name=not_found"
+          "Couldn't find #{Klass.name} with name = not_found"
         ) do
-          klass = student.klasss.find_by!(:name, "not_found")
+          klass = student.klasss.find_by!(name: "not_found")
         end
       end
 
@@ -189,7 +189,7 @@ module {{adapter.capitalize.id}}
 
         expect_raises(
           Granite::Querying::NotFound,
-          "Couldn't find #{Klass.name} with id=#{id}"
+          "Couldn't find #{Klass.name} with id = #{id}"
         ) do
           student.klasss.find!(id)
         end

--- a/spec/granite/fields/timestamps_spec.cr
+++ b/spec/granite/fields/timestamps_spec.cr
@@ -88,7 +88,7 @@ module {{adapter.capitalize.id}}
         Parent.import(to_import)
         import_time = Time.now
 
-        parent1 = Parent.find_by! :name, "ParentOne"
+        parent1 = Parent.find_by!(name: "ParentOne")
         parent1.name.should eq "ParentOne"
         parent1.created_at.not_nil!.epoch.should eq import_time.epoch
         parent1.updated_at.not_nil!.epoch.should eq import_time.epoch
@@ -101,7 +101,7 @@ module {{adapter.capitalize.id}}
         Parent.import(to_update, update_on_duplicate: true, columns: ["name"])
         update_time = Time.now
 
-        parent1_edited = Parent.find_by! :name, "ParentOneEdited"
+        parent1_edited = Parent.find_by!(name: "ParentOneEdited")
         parent1_edited.name.should eq "ParentOneEdited"
         parent1_edited.created_at.not_nil!.epoch.should eq import_time.epoch
         parent1_edited.updated_at.not_nil!.epoch.should eq update_time.epoch

--- a/spec/granite/querying/find_by_spec.cr
+++ b/spec/granite/querying/find_by_spec.cr
@@ -11,10 +11,10 @@ module {{adapter.capitalize.id}}
       model.name = name
       model.save
 
-      found = Parent.find_by("name", name)
+      found = Parent.find_by(name: name)
       found.not_nil!.id.should eq model.id
 
-      found = Parent.find_by!("name", name)
+      found = Parent.find_by!(name: name)
       found.should be_a(Parent)
     end
 
@@ -26,10 +26,10 @@ module {{adapter.capitalize.id}}
       model.name = name
       model.save
 
-      found = Parent.find_by(:name, name)
+      found = Parent.find_by(name: name)
       found.not_nil!.id.should eq model.id
 
-      found = Parent.find_by!(:name, name)
+      found = Parent.find_by!(name: name)
       found.id.should eq model.id
     end
 
@@ -41,20 +41,20 @@ module {{adapter.capitalize.id}}
       model.all = value
       model.save
 
-      found = ReservedWord.find_by("all", value)
+      found = ReservedWord.find_by(all: value)
       found.not_nil!.id.should eq model.id
 
-      found = ReservedWord.find_by!(:all, value)
+      found = ReservedWord.find_by!(all: value)
       found.id.should eq model.id
     end
 
     it "returns nil or raises if no result" do
       Parent.clear
-      found = Parent.find_by("name", "xxx")
+      found = Parent.find_by(name: "xxx")
       found.should be_nil
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with name=xxx/) do
-        Parent.find_by!("name", "xxx")
+      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with name = xxx/) do
+        Parent.find_by!(name: "xxx")
       end
     end
   end

--- a/spec/granite/querying/find_by_spec.cr
+++ b/spec/granite/querying/find_by_spec.cr
@@ -18,22 +18,23 @@ module {{adapter.capitalize.id}}
       found.should be_a(Parent)
     end
 
-    it "finds an object with a symbol field" do
-      Parent.clear
-      name = "robinson"
+    it "works with multiple arguments" do
+      Review.clear
 
-      model = Parent.new
-      model.name = name
-      model.save
+      Review.create(name: "review1", upvotes: 2.to_i64)
+      Review.create(name: "review2", upvotes: 0.to_i64)
+      Review.create(name: "review1", upvotes: 10.to_i64)
 
-      found = Parent.find_by(name: name)
-      found.not_nil!.id.should eq model.id
+      Review.find_by(name: "review1").not_nil!.id.should eq 1
+      Review.find_by(upvotes: 0).not_nil!.id.should eq 2
+      Review.find_by(name: "review1", upvotes: 10).not_nil!.id.should eq 3
 
-      found = Parent.find_by!(name: name)
-      found.id.should eq model.id
+      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Review.* with name = review1 and upvotes = 20/) do
+        Review.find_by!(name: "review1", upvotes: 20)
+      end
     end
 
-    it "also works with reserved words" do
+    it "works with reserved words" do
       Parent.clear
       value = "robinson"
 

--- a/spec/granite/querying/find_by_spec.cr
+++ b/spec/granite/querying/find_by_spec.cr
@@ -29,7 +29,7 @@ module {{adapter.capitalize.id}}
       Review.find_by(upvotes: 0).not_nil!.id.should eq 2
       Review.find_by(name: "review1", upvotes: 10).not_nil!.id.should eq 3
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Review.* with name = review1 and upvotes = 20/) do
+      expect_raises(Granite::Querying::NotFound, /No .*Review.* found where name = review1 and upvotes = 20/) do
         Review.find_by!(name: "review1", upvotes: 20)
       end
     end
@@ -54,7 +54,7 @@ module {{adapter.capitalize.id}}
       found = Parent.find_by(name: "xxx")
       found.should be_nil
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with name = xxx/) do
+      expect_raises(Granite::Querying::NotFound, /No .*Parent.* found where name = xxx/) do
         Parent.find_by!(name: "xxx")
       end
     end

--- a/spec/granite/querying/find_spec.cr
+++ b/spec/granite/querying/find_spec.cr
@@ -61,7 +61,7 @@ module {{adapter.capitalize.id}}
       found = Parent.find 0
       found.should be_nil
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with id = 0/) do
+      expect_raises(Granite::Querying::NotFound, /No .*Parent.* found where id = 0/) do
         Parent.find! 0
       end
     end

--- a/spec/granite/querying/find_spec.cr
+++ b/spec/granite/querying/find_spec.cr
@@ -61,7 +61,7 @@ module {{adapter.capitalize.id}}
       found = Parent.find 0
       found.should be_nil
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with id=0/) do
+      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with id = 0/) do
         Parent.find! 0
       end
     end

--- a/spec/granite/querying/first_spec.cr
+++ b/spec/granite/querying/first_spec.cr
@@ -51,7 +51,7 @@ module {{adapter.capitalize.id}}
       found = Parent.first("WHERE name = 'Test 2'")
       found.should be nil
 
-      expect_raises(Granite::Querying::NotFound, /Couldn't find .*Parent.* with first\(WHERE name = 'Test 2'\)/) do
+      expect_raises(Granite::Querying::NotFound, /No .*Parent.* found with first\(WHERE name = 'Test 2'\)/) do
         Parent.first!("WHERE name = 'Test 2'")
       end
     end

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -43,9 +43,6 @@ abstract class Granite::Adapter::Base
   # params is the query and params that is passed in via .all() method
   abstract def select(table_name, fields, clause = "", params = nil, &block)
 
-  # select_one is used by the find method.
-  # abstract def select_one(table_name, fields, field, id, &block)
-
   # This will insert a row in the database and return the id generated.
   abstract def insert(table_name, fields, params, lastval) : Int64
 

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -44,21 +44,19 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     end
   end
 
-  # select_one is used by the find method.
-  # it checks id by default, but one can
-  # pass another field.
-  def select_one(table_name, fields, field, id, &block)
+  # Returns the first row matching the given criteria.
+  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
       stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
       stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{quote(field)}=? LIMIT 1"
+      stmt << " WHERE #{criteria.map { |name| "#{quote(table_name)}.#{quote(name.to_s)} = ?" }.join(" AND ")} LIMIT 1"
     end
 
-    log statement, id
+    log statement, params
 
     open do |db|
-      db.query_one? statement, id do |rs|
+      db.query_one? statement, params do |rs|
         yield rs
       end
     end

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -44,24 +44,6 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     end
   end
 
-  # Returns the first row matching the given criteria.
-  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{criteria.map { |name| "#{quote(table_name)}.#{quote(name.to_s)} = ?" }.join(" AND ")} LIMIT 1"
-    end
-
-    log statement, params
-
-    open do |db|
-      db.query_one? statement, params do |rs|
-        yield rs
-      end
-    end
-  end
-
   def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -46,24 +46,6 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
   end
 
-  # Returns the first row matching the given criteria.
-  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{criteria.map_with_index { |name, idx| "#{quote(table_name)}.#{quote(name.to_s)} = $#{idx + 1}" }.join(" AND ")} LIMIT 1"
-    end
-
-    log statement, params
-
-    open do |db|
-      db.query_one? statement, params do |rs|
-        yield rs
-      end
-    end
-  end
-
   def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -46,19 +46,19 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
   end
 
-  # select_one is used by the find method.
-  def select_one(table_name, fields, field, id, &block)
+  # Returns the first row matching the given criteria.
+  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
       stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
       stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{quote(field)}=$1 LIMIT 1"
+      stmt << " WHERE #{criteria.map_with_index { |name, idx| "#{quote(table_name)}.#{quote(name.to_s)} = $#{idx + 1}" }.join(" AND ")} LIMIT 1"
     end
 
-    log statement, id
+    log statement, params
 
     open do |db|
-      db.query_one? statement, id do |rs|
+      db.query_one? statement, params do |rs|
         yield rs
       end
     end

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -46,24 +46,6 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
   end
 
-  # Returns the first row matching the given criteria.
-  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{criteria.map { |name| "#{quote(table_name)}.#{quote(name.to_s)} = ?" }.join(" AND ")} LIMIT 1"
-    end
-
-    log statement, params
-
-    open do |db|
-      db.query_one? statement, params do |rs|
-        yield rs
-      end
-    end
-  end
-
   def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -46,19 +46,19 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
   end
 
-  # select_one is used by the find method.
-  def select_one(table_name, fields, field, id, &block)
+  # Returns the first row matching the given criteria.
+  def select_one(table_name : String, fields : Array(String), criteria : Array(Symbol | String), params : Array(DB::Any), &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
       stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
       stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{quote(field)}=:id LIMIT 1"
+      stmt << " WHERE #{criteria.map { |name| "#{quote(table_name)}.#{quote(name.to_s)} = ?" }.join(" AND ")} LIMIT 1"
     end
 
-    log statement, id
+    log statement, params
 
     open do |db|
-      db.query_one? statement, id do |rs|
+      db.query_one? statement, params do |rs|
         yield rs
       end
     end

--- a/src/granite/association_collection.cr
+++ b/src/granite/association_collection.cr
@@ -13,13 +13,13 @@ class Granite::AssociationCollection(Owner, Target)
 
   def find_by(**args)
     Target.first(
-      "#{query} AND #{args.map { |arg| "#{Target.table_name}.#{arg} = ?" }.join(" AND ")}",
+      "#{query} AND #{args.map { |arg| "#{Target.quote(Target.table_name)}.#{Target.quote(arg.to_s)} = ?" }.join(" AND ")}",
       [owner.id] + args.values.to_a
     )
   end
 
   def find_by!(**args)
-    find_by(**args) || raise Granite::Querying::NotFound.new("Couldn't find #{Target.name} with #{args.map { |k, v| "#{k} = #{v}" }.join(" and ")}")
+    find_by(**args) || raise Granite::Querying::NotFound.new("No #{Target.name} found where #{args.map { |k, v| "#{k} = #{v}" }.join(" and ")}")
   end
 
   def find(value)

--- a/src/granite/association_collection.cr
+++ b/src/granite/association_collection.cr
@@ -11,26 +11,23 @@ class Granite::AssociationCollection(Owner, Target)
     )
   end
 
-  def find_by(field : String | Symbol, value)
+  def find_by(**args)
     Target.first(
-      [query, "AND #{Target.table_name}.#{field} = ?"].join(" "),
-      [owner.id, value]
+      "#{query} AND #{args.map { |arg| "#{Target.table_name}.#{arg} = ?" }.join(" AND ")}",
+      [owner.id] + args.values.to_a
     )
   end
 
-  def find_by!(field : String | Symbol, value)
-    find_by(field, value) ||
-      raise Granite::Querying::NotFound.new(
-        "Couldn't find #{Target.name} with #{field}=#{value}"
-      )
+  def find_by!(**args)
+    find_by(**args) || raise Granite::Querying::NotFound.new("Couldn't find #{Target.name} with #{args.map { |k, v| "#{k} = #{v}" }.join(" and ")}")
   end
 
   def find(value)
-    find_by(Target.primary_name, value)
+    Target.find(value)
   end
 
   def find!(value)
-    find_by!(Target.primary_name, value)
+    Target.find!(value)
   end
 
   private getter owner

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -70,7 +70,7 @@ module Granite::Querying
   end
 
   def first!(clause = "", params = [] of DB::Any)
-    first(clause, params) || raise NotFound.new("Couldn't find " + {{@type.name.stringify}} + " with first(#{clause})")
+    first(clause, params) || raise NotFound.new("No #{{{@type.name.stringify}}} found with first(#{clause})")
   end
 
   # find returns the row with the primary key specified. Otherwise nil.
@@ -80,7 +80,7 @@ module Granite::Querying
 
   # find returns the row with the primary key specified. Otherwise raises an exception.
   def find!(value)
-    find(value) || raise Granite::Querying::NotFound.new("Couldn't find #{{{@type.name.stringify}}} with #{@@primary_name} = #{value}")
+    find(value) || raise Granite::Querying::NotFound.new("No #{{{@type.name.stringify}}} found where #{@@primary_name} = #{value}")
   end
 
   # find_by returns the first row found that matches the given criteria. Otherwise nil.
@@ -90,7 +90,7 @@ module Granite::Querying
 
   # find_by returns the first row found that matches the given criteria. Otherwise raises an exception.
   def find_by!(**args)
-    find_by(**args) || raise NotFound.new("Couldn't find #{{{@type.name.stringify}}} with #{args.map { |k, v| "#{k} = #{v}" }.join(" and ")}")
+    find_by(**args) || raise NotFound.new("No #{{{@type.name.stringify}}} found where #{args.map { |k, v| "#{k} = #{v}" }.join(" and ")}")
   end
 
   def find_each(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -80,7 +80,7 @@ module Granite::Querying
 
   # find returns the row with the primary key specified. Otherwise raises an exception.
   def find!(value)
-    first("WHERE #{@@primary_name} = ?", value) || raise Granite::Querying::NotFound.new("Couldn't find #{{{@type.name.stringify}}} with #{@@primary_name} = #{value}")
+    find(value) || raise Granite::Querying::NotFound.new("Couldn't find #{{{@type.name.stringify}}} with #{@@primary_name} = #{value}")
   end
 
   # find_by returns the first row found that matches the given criteria. Otherwise nil.

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -85,9 +85,7 @@ module Granite::Querying
 
   # find_by returns the first row found that matches the given criteria. Otherwise nil.
   def find_by(**args)
-    @@adapter.select_one(@@table_name, fields, args.keys.to_a, args.values.to_a) do |result|
-      from_sql(result)
-    end
+    first("WHERE #{args.map { |name| "#{quote(@@table_name)}.#{quote(name.to_s)} = ?" }.join(" AND ")}", args.values.to_a)
   end
 
   # find_by returns the first row found that matches the given criteria. Otherwise raises an exception.


### PR DESCRIPTION
This PR (#206) allows `find_by` and `find_by!` to accept multiple criteria.

This does change the syntax of the method, but i think this is a better solution long term than having two different methods with different syntaxes for each.

This touches a fair bit of the `querying.cr` since `find` was wrapping `find_by`, and since you cannot declare a dynamic keyed NamedTuple to pass to the new `find_by` I had to replace it with `first`

fixes #206 