### PR TITLE
added query macro, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,12 +340,13 @@ puts "deleted" unless post
 
 ### Queries
 
-The where clause will give you full control over your query.
+The query macro and where clause combine to give you full control over your query.
 
 #### All
 
-When using the `all` method, the SQL selected fields will always match the
-fields specified in the model.
+When using the `all` method, the SQL selected fields will match the
+fields specified in the model unless the `query` macro was used to customize
+the SELECT.
 
 Always pass in parameters to avoid SQL Injection.  Use a `?`
 in your query as placeholder. Checkout the [Crystal DB Driver](https://github.com/crystal-lang/crystal-db)
@@ -387,6 +388,31 @@ This is the same as:
 
 ```crystal
 post = Post.all("ORDER BY posts.name DESC LIMIT 1").first
+```
+
+#### Customizing SELECT
+
+The `query` macro allows you to customize the entire query, including the SELECT portion.  This shouldn't be necessary in most cases, but allows you to craft more complex (i.e. cross-table) queries if needed:
+
+```crystal
+class CustomView < Granite:Base
+  adapter pg
+  field articlebody : String
+  field commentbody : String
+
+  query <<-SQL
+    SELECT articles.articlebody, comments.commentbody 
+    FROM articles 
+    JOIN comments 
+    ON comments.articleid = articles.id
+  SQL
+end
+```
+
+You can combine this with an argument to `all` or `first` for maximum flexibility:
+
+```crystal
+results = CustomView.all("WHERE articles.author = ?", ["Noah"])
 ```
 
 ### Relationships

--- a/spec/granite/select/select_spec.cr
+++ b/spec/granite/select/select_spec.cr
@@ -1,0 +1,47 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} custom select" do
+    it "generates custom SQL with the query macro" do
+      ArticleViewModel.select.should eq "SELECT articles.id, articles.articlebody, comments.commentbody FROM articles JOIN comments ON comments.articleid = articles.id"
+    end
+
+    it "uses custom SQL to populate a view model - #all" do
+      first = Article.new.tap do |model|
+        model.articlebody = "The Article Body"
+        model.save
+      end
+
+      second = Comment.new.tap do |model|
+        model.commentbody = "The Comment Body"
+        model.articleid = first.id
+        model.save
+      end
+
+      viewmodel = ArticleViewModel.all
+      viewmodel.first.articlebody.should eq "The Article Body"
+      viewmodel.first.commentbody.should eq "The Comment Body"
+    end
+
+    # TODO:  `find` on this ViewModel fails because "id" is ambiguous in a complex SELECT.
+
+    # it "uses custom SQL to populate a view model - #find" do
+    #   first = Article.new.tap do |model|
+    #     model.articlebody = "The Article Body"
+    #     model.save
+    #   end
+
+    #   second = Comment.new.tap do |model|
+    #     model.commentbody = "The Comment Body"
+    #     model.articleid = first.id
+    #     model.save
+    #   end
+
+    #   viewmodel = ArticleViewModel.find!(first.id)
+    #   viewmodel.articlebody.should eq "The Article Body"
+    #   viewmodel.commentbody.should eq "The Comment Body"
+    # end
+  end
+end
+{% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -211,6 +211,34 @@ require "uuid"
       field name : String
     end
 
+    class Article < Granite::Base
+      adapter {{ adapter.id }}
+      table_name articles
+
+      primary id : Int64
+      field articlebody : String
+    end
+
+    class Comment < Granite::Base
+      adapter {{ adapter.id }}
+      table_name comments
+
+      primary id : Int64
+      field commentbody : String
+      field articleid : Int64
+    end
+
+    class ArticleViewModel < Granite::Base
+      adapter {{ adapter.id }}
+
+      field articlebody : String
+      field commentbody : String
+
+      query <<-SQL
+        SELECT articles.id, articles.articlebody, comments.commentbody FROM articles JOIN comments ON comments.articleid = articles.id
+      SQL
+    end
+
     Parent.migrator.drop_and_create
     Teacher.migrator.drop_and_create
     Student.migrator.drop_and_create
@@ -231,5 +259,8 @@ require "uuid"
     Item.migrator.drop_and_create
     NonAutoDefaultPK.migrator.drop_and_create
     NonAutoCustomPK.migrator.drop_and_create
+    Article.migrator.drop_and_create
+    Comment.migrator.drop_and_create
+
   end
 {% end %}

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -38,10 +38,11 @@ abstract class Granite::Adapter::Base
   # remove all rows from a table and reset the counter on the id.
   abstract def clear(table_name)
 
-  # select performs a query against a table.  The table_name and fields are
-  # configured using the sql_mapping directive in your model.  The clause and
-  # params is the query and params that is passed in via .all() method
-  abstract def select(table_name, fields, clause = "", params = nil, &block)
+  # select performs a query against a table.  The query object containes table_name,
+  # fields (configured using the sql_mapping directive in your model), and an optional
+  # raw query string.  The clause and params is the query and params that is passed
+  # in via .all() method
+  abstract def select(query : Granite::Select::Container, clause = "", params = nil, &block)
 
   # select_one is used by the find method.
   # abstract def select_one(table_name, fields, field, id, &block)

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -30,14 +30,10 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   # raw query string.  The clause and params is the query and params that is passed
   # in via .all() method
   def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
-    if query.custom.size > 0
-      statement = query.custom
-    else
-      statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)} #{clause}"
-      end
+    statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)} #{clause}"
     end
 
     log statement, params
@@ -53,14 +49,10 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   # it checks id by default, but one can
   # pass another field.
   def select_one(query : Granite::Select::Container, field, id, &block)
-    if query.custom.size > 0
-      initial_statement = query.custom
-    else
-      initial_statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)}"
-      end
+    initial_statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)}"
     end
 
     statement = "#{initial_statement} WHERE #{quote(field)}=? LIMIT 1"

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -25,16 +25,21 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
   end
 
-  # select performs a query against a table.  The table_name and fields are
-  # configured using the sql_mapping directive in your model.  The clause and
-  # params is the query and params that is passed in via .all() method
-  def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
+  # select performs a query against a table.  The query object containes table_name,
+  # fields (configured using the sql_mapping directive in your model), and an optional
+  # raw query string.  The clause and params is the query and params that is passed
+  # in via .all() method
+  def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
     clause = _ensure_clause_template(clause)
 
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)} #{clause}"
+    if query.custom.size > 0
+      statement = query.custom
+    else
+      statement = String.build do |stmt|
+        stmt << "SELECT "
+        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+        stmt << " FROM #{quote(query.table_name)} #{clause}"
+      end
     end
 
     log statement, params
@@ -47,13 +52,18 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   end
 
   # select_one is used by the find method.
-  def select_one(table_name, fields, field, id, &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{quote(field)}=$1 LIMIT 1"
+  def select_one(query : Granite::Select::Container, field, id, &block)
+    if query.custom.size > 0
+      initial_statement = query.custom
+    else
+      initial_statement = String.build do |stmt|
+        stmt << "SELECT "
+        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+        stmt << " FROM #{quote(query.table_name)}"
+      end
     end
+
+    statement = "#{initial_statement} WHERE #{quote(field)}=$1 LIMIT 1"
 
     log statement, id
 

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -31,15 +31,10 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   # in via .all() method
   def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
     clause = _ensure_clause_template(clause)
-
-    if query.custom.size > 0
-      statement = query.custom
-    else
-      statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)} #{clause}"
-      end
+    statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)} #{clause}"
     end
 
     log statement, params
@@ -53,14 +48,10 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
 
   # select_one is used by the find method.
   def select_one(query : Granite::Select::Container, field, id, &block)
-    if query.custom.size > 0
-      initial_statement = query.custom
-    else
-      initial_statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)}"
-      end
+    initial_statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)}"
     end
 
     statement = "#{initial_statement} WHERE #{quote(field)}=$1 LIMIT 1"

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -27,14 +27,19 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
   end
 
-  # select performs a query against a table.  The table_name and fields are
-  # configured using the sql_mapping directive in your model.  The clause and
-  # params is the query and params that is passed in via .all() method
-  def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)} #{clause}"
+  # select performs a query against a table.  The query object containes table_name,
+  # fields (configured using the sql_mapping directive in your model), and an optional
+  # raw query string.  The clause and params is the query and params that is passed
+  # in via .all() method
+  def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
+    if query.custom.size > 0
+      statement = query.custom
+    else
+      statement = String.build do |stmt|
+        stmt << "SELECT "
+        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+        stmt << " FROM #{quote(query.table_name)} #{clause}"
+      end
     end
 
     log statement, params
@@ -47,13 +52,18 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   end
 
   # select_one is used by the find method.
-  def select_one(table_name, fields, field, id, &block)
-    statement = String.build do |stmt|
-      stmt << "SELECT "
-      stmt << fields.map { |name| "#{quote(table_name)}.#{quote(name)}" }.join(", ")
-      stmt << " FROM #{quote(table_name)}"
-      stmt << " WHERE #{quote(field)}=:id LIMIT 1"
+  def select_one(query : Granite::Select::Container, field, id, &block)
+    if query.custom.size > 0
+      initial_statement = query.custom
+    else
+      initial_statement = String.build do |stmt|
+        stmt << "SELECT "
+        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+        stmt << " FROM #{quote(query.table_name)}"
+      end
     end
+
+    statement = "#{initial_statement} WHERE #{quote(field)}=:id LIMIT 1"
 
     log statement, id
 

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -32,14 +32,10 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   # raw query string.  The clause and params is the query and params that is passed
   # in via .all() method
   def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
-    if query.custom.size > 0
-      statement = query.custom
-    else
-      statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)} #{clause}"
-      end
+    statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)} #{clause}"
     end
 
     log statement, params
@@ -53,14 +49,10 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
   # select_one is used by the find method.
   def select_one(query : Granite::Select::Container, field, id, &block)
-    if query.custom.size > 0
-      initial_statement = query.custom
-    else
-      initial_statement = String.build do |stmt|
-        stmt << "SELECT "
-        stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
-        stmt << " FROM #{quote(query.table_name)}"
-      end
+    initial_statement = query.custom || String.build do |stmt|
+      stmt << "SELECT "
+      stmt << query.fields.map { |name| "#{quote(query.table_name)}.#{quote(name)}" }.join(", ")
+      stmt << " FROM #{quote(query.table_name)}"
     end
 
     statement = "#{initial_statement} WHERE #{quote(field)}=:id LIMIT 1"

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -9,6 +9,7 @@ require "./table"
 require "./transactions"
 require "./validators"
 require "./migrator"
+require "./select"
 require "./version"
 
 # Granite::Base is the base class for your model objects.
@@ -20,6 +21,7 @@ class Granite::Base
   include Transactions
   include Validators
   include Migrator
+  include Select
 
   extend Querying
   extend Transactions::ClassMethods
@@ -28,6 +30,7 @@ class Granite::Base
     macro finished
       __process_table
       __process_fields
+      __process_select
       __process_querying
       __process_transactions
       __process_migrator

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -44,7 +44,7 @@ module Granite::Querying
 
   def raw_all(clause = "", params = [] of DB::Any)
     rows = [] of self
-    @@adapter.select(@@table_name, fields, clause, params) do |results|
+    @@adapter.select(@@select, clause, params) do |results|
       results.each do
         rows << from_sql(results)
       end
@@ -87,7 +87,7 @@ module Granite::Querying
   # find_by returns the first row found where the field maches the value
   def find_by(field : String | Symbol, value)
     row = nil
-    @@adapter.select_one(@@table_name, fields, field.to_s, value) do |result|
+    @@adapter.select_one(@@select, field.to_s, value) do |result|
       row = from_sql(result) if result
     end
     return row

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -3,7 +3,7 @@ module Granite::Select
     property custom : String?
     getter table_name, fields
 
-    def initialize(@custom, @table_name = "", @fields = [] of String)
+    def initialize(@custom = nil, @table_name = "", @fields = [] of String)
     end
   end
 

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -1,9 +1,9 @@
 module Granite::Select
   struct Container
-    property custom
+    property custom : String?
     getter table_name, fields
 
-    def initialize(@custom = "", @table_name = "", @fields = [] of String)
+    def initialize(@custom, @table_name = "", @fields = [] of String)
     end
   end
 

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -1,0 +1,21 @@
+module Granite::Select
+  struct Container
+    property custom
+    getter table_name, fields
+
+    def initialize(@custom = "", @table_name = "", @fields = [] of String)
+    end
+  end
+
+  macro query(text)
+    @@select.custom = {{text.strip}}
+
+    def self.select
+      @@select.custom
+    end
+  end
+
+  macro __process_select
+    @@select = Container.new(table_name: @@table_name, fields: fields)
+  end
+end


### PR DESCRIPTION
This PR (#184 & #200) allows you to customize the SQL used in the SELECT portion of the query (or the entire query if necessary) by adding the `query` macro.

The major limitation is that when using a highly-modified `query`, the save/update functionality of the model will likely break.  In the issue @drujensen suggested taking a more complete View Model approach, and I agree with that entirely, but wanted to start with a slightly narrower scope.  So this is "View Model Lite".  Baby steps.  Likewise, `find` may also break depending on how the query is modified.

Also, naming is hard.  I'm not wedded to any of the names used, and particularly with things like Query, Select, etc., things might get complex.

(PS - Please feel free to rip to shreds :) I'm new to this type of contribution so am eager to learn & improve in both style and substance.  Happy to make as many changes as needed.)