### PR TITLE
close result set after using it

### DIFF
--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -8,7 +8,7 @@ module Granite::Querying
       \{% primary_type = PRIMARY[:type] %}
 
       # Create the from_sql method
-      def self.from_sql(result)
+      def self.from_sql(result : DB::ResultSet)
         model = \{{@type.name.id}}.new
         model.set_attributes(result)
         model
@@ -31,6 +31,7 @@ module Granite::Querying
             self.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
           \{% end %}
         \{% end %}
+        result.close
         return self
       end
     end


### PR DESCRIPTION
Feedback from @bcardiff and documentation on connection pools, we need to explicitly close the  result set after using it.  This will return the connection back to the connection pool and may be the cause of a connection leak reported

https://crystal-lang.org/docs/database/connection_pool.html
