### PR TITLE
Fix last insert ID race condition

### DIFF
--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -14,6 +14,23 @@ module {{adapter.capitalize.id}}
       parent.id.should be_nil
     end
 
+    it "doesn't have a race condition on IDs" do
+      channel = Channel(Int64).new
+
+      2.times do
+        spawn do
+          parent = Parent.new(name: "Test Parent")
+          parent.save
+          channel.send(parent.id.not_nil!)
+        end
+      end
+
+      id1 = channel.receive
+      id2 = channel.receive
+
+      id1.should_not eq id2
+    end
+
     describe "with a custom primary key" do
       it "creates a new object" do
         school = School.create(name: "Test School")

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -76,11 +76,13 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     log statement, params
 
     open do |db|
-      db.exec statement, params
-      if lastval
-        return db.scalar(last_val()).as(Int64)
-      else
-        return -1_i64
+      db.using_connection do |conn|
+        conn.exec statement, params
+        if lastval
+          return conn.scalar(last_val()).as(Int64)
+        else
+          return -1_i64
+        end
       end
     end
   end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -66,14 +66,14 @@ module Granite::Transactions
       end
       begin
         {% if primary_type.id == "Int32" %}
-          @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: true).to_i32
+          @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: "{{primary_name}}").to_i32
         {% elsif primary_type.id == "Int64" %}
-          @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: true)
+          @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: "{{primary_name}}")
         {% elsif primary_auto == true %}
           {% raise "Failed to define #{@type.name}#save: Primary key must be Int(32|64), or set `auto: false` for natural keys.\n\n  primary #{primary_name} : #{primary_type}, auto: false\n" %}
         {% else %}
           if @{{primary_name}}
-            @@adapter.insert(@@table_name, fields, params, lastval: false)
+            @@adapter.insert(@@table_name, fields, params, lastval: nil)
           else
             message = "Primary key('{{primary_name}}') cannot be null"
             errors << Granite::Error.new("{{primary_name}}", message)


### PR DESCRIPTION
First of all, thanks for the great library!

While working on an application using Granite we noticed a race condition with the IDs being returned for instances. In our case, it was two concurrent API requests to a create API - both records were being returned with the same ID.

The failing spec I've added here is a minimal example to reproduce the issue. We discovered it using postgres but it also appears to occur for mysql. I've included fixes for both adapters.

Strangely, the issue doesn't seem to occur with sqlite any time I have run the specs. I'm not sure if this is coincidence, or if some difference in the driver prevents the fiber from yielding in the same way. For now I've left the adapter untouched, but it may be more correct to wrap it in a `using_connection` block the same way I have with mysql.

Thanks for all of your work on this library so far.

Charlie