### PR TITLE
bugfix: querybuilder logger

### DIFF
--- a/src/granite/query/executors/base.cr
+++ b/src/granite/query/executors/base.cr
@@ -5,7 +5,9 @@ module Granite::Query::Executor
     end
 
     def log(*messages)
-      Granite::Logger.log messages
+      messages.each do |message|
+        Granite.settings.logger.info message
+      end
     end
   end
 end


### PR DESCRIPTION
The querybuilder as is doesn't work and isn't usable because the logger call isn't working, resulting in this error message:

```
in lib/granite/src/granite/query/executors/base.cr:8: undefined constant Granite::Logger

      Granite::Logger.log messages
      ^~~~~~~~~~~~~~~
```

This corrects the showstopping bug, and lets this appear in the logs instead:

![amber watch 2018-06-08 15-18-18](https://user-images.githubusercontent.com/208647/41181954-f02c8780-6b30-11e8-8801-c4d0568be8cb.png)

The log formatting still needs a bit of work, but at least it _compiles_

🍌 