### PR TITLE
Update to crystal 0.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev l
 
 WORKDIR /app/user
 
-ADD . /app/user
-
+COPY shard.yml shard.lock ./
 RUN shards install
+
+COPY . /app/user
 
 CMD ["crystal", "spec"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app/user
 
 ADD . /app/user
 
-RUN crystal deps
+RUN shards install
 
 CMD ["crystal", "spec"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.24.2
+FROM crystallang/crystal:0.25.0
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev libsqlite3-dev libmysqlclient-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends libpq-dev l
 
 WORKDIR /app/user
 
-COPY shard.yml shard.lock ./
+COPY shard.yml ./
 RUN shards install
 
 COPY . /app/user

--- a/shard.yml
+++ b/shard.yml
@@ -23,4 +23,4 @@ development_dependencies:
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.14.1
+    version: ~> 0.15.0

--- a/spec/granite/fields/timestamps_spec.cr
+++ b/spec/granite/fields/timestamps_spec.cr
@@ -5,12 +5,6 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   {%
     avoid_macro_bug = 1 # https://github.com/crystal-lang/crystal/issues/5724
-
-    if adapter == "pg"
-      time_kind_on_read = "Time::Kind::Utc".id
-    else
-      time_kind_on_read = "Time::Kind::Unspecified".id
-    end
   %}
 
   describe "{{ adapter.id }} timestamps" do
@@ -21,8 +15,8 @@ module {{adapter.capitalize.id}}
       original_timestamp = parent.created_at!
       read_timestamp = found_parent.created_at!
 
-      original_timestamp.kind.should eq Time::Kind::Utc
-      read_timestamp.kind.should eq {{ time_kind_on_read }}
+      original_timestamp.location.should eq Time::Location::UTC
+      read_timestamp.location.should eq Time::Location::UTC
     end
 
     it "consistently uses UTC for updated_at" do
@@ -32,8 +26,8 @@ module {{adapter.capitalize.id}}
       original_timestamp = parent.updated_at!
       read_timestamp = found_parent.updated_at!
 
-      original_timestamp.kind.should eq Time::Kind::Utc
-      read_timestamp.kind.should eq {{ time_kind_on_read }}
+      original_timestamp.location.should eq Time::Location::UTC
+      read_timestamp.location.should eq Time::Location::UTC
     end
 
     it "truncates the subsecond parts of created_at" do
@@ -73,8 +67,8 @@ module {{adapter.capitalize.id}}
         parents.size.should eq 3
 
         parents.each do |parent|
-          parent.updated_at.not_nil!.kind.should eq {{ time_kind_on_read }}
-          parent.created_at.not_nil!.kind.should eq {{ time_kind_on_read }}
+          parent.updated_at.not_nil!.location.should eq Time::Location::UTC
+          parent.created_at.not_nil!.location.should eq Time::Location::UTC
           found_grandma.updated_at.not_nil!.epoch.should eq parent.updated_at.not_nil!.epoch
           found_grandma.created_at.not_nil!.epoch.should eq parent.created_at.not_nil!.epoch
         end

--- a/spec/granite/fields/timestamps_spec.cr
+++ b/spec/granite/fields/timestamps_spec.cr
@@ -5,6 +5,12 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   {%
     avoid_macro_bug = 1 # https://github.com/crystal-lang/crystal/issues/5724
+
+    if adapter == "pg"
+      time_kind_on_read = "Time::Location::UTC".id
+    else
+      time_kind_on_read = "Time::Location.local".id
+    end
   %}
 
   describe "{{ adapter.id }} timestamps" do
@@ -16,7 +22,7 @@ module {{adapter.capitalize.id}}
       read_timestamp = found_parent.created_at!
 
       original_timestamp.location.should eq Time::Location::UTC
-      read_timestamp.location.should eq Time::Location::UTC
+      read_timestamp.location.should eq {{ time_kind_on_read }}
     end
 
     it "consistently uses UTC for updated_at" do
@@ -27,7 +33,7 @@ module {{adapter.capitalize.id}}
       read_timestamp = found_parent.updated_at!
 
       original_timestamp.location.should eq Time::Location::UTC
-      read_timestamp.location.should eq Time::Location::UTC
+      read_timestamp.location.should eq {{ time_kind_on_read }}
     end
 
     it "truncates the subsecond parts of created_at" do
@@ -67,8 +73,8 @@ module {{adapter.capitalize.id}}
         parents.size.should eq 3
 
         parents.each do |parent|
-          parent.updated_at.not_nil!.location.should eq Time::Location::UTC
-          parent.created_at.not_nil!.location.should eq Time::Location::UTC
+          parent.updated_at.not_nil!.location.should eq {{ time_kind_on_read }}
+          parent.created_at.not_nil!.location.should eq {{ time_kind_on_read }}
           found_grandma.updated_at.not_nil!.epoch.should eq parent.updated_at.not_nil!.epoch
           found_grandma.created_at.not_nil!.epoch.should eq parent.created_at.not_nil!.epoch
         end

--- a/spec/granite/querying/find_by_spec.cr
+++ b/spec/granite/querying/find_by_spec.cr
@@ -23,11 +23,10 @@ module {{adapter.capitalize.id}}
 
       Review.create(name: "review1", upvotes: 2.to_i64)
       Review.create(name: "review2", upvotes: 0.to_i64)
-      Review.create(name: "review1", upvotes: 10.to_i64)
 
-      Review.find_by(name: "review1").not_nil!.id.should eq 1
-      Review.find_by(upvotes: 0).not_nil!.id.should eq 2
-      Review.find_by(name: "review1", upvotes: 10).not_nil!.id.should eq 3
+      expected = Review.create(name: "review3", upvotes: 10.to_i64)
+
+      Review.find_by(name: "review3", upvotes: 10).not_nil!.id.should eq expected.id
 
       expect_raises(Granite::Querying::NotFound, /No .*Review.* found where name = review1 and upvotes = 20/) do
         Review.find_by!(name: "review1", upvotes: 20)

--- a/spec/granite/querying/from_sql_spec.cr
+++ b/spec/granite/querying/from_sql_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 macro build_review_emitter(driver)
   {%
     timestamp = if driver == "sqlite"
-                  "2018-04-09 13:33:46"
+                  "Time.now.to_s(Granite::DATETIME_FORMAT)".id
                 else
                   "Time.now".id
                 end

--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -36,7 +36,8 @@ describe Granite::Base do
   end
 
   it "takes JSON::Any" do
-    json_str = %({"name": "json::anyReview", "user_id": 99, "upvotes": 2, "sentiment": 1.23, "interest": 4.56, "published": true, "created_at": "2016-02-15 10:20:30"})
+    time_now = Time.now.at_beginning_of_second
+    json_str = %({"name": "json::anyReview", "user_id": 99, "upvotes": 2, "sentiment": 1.23, "interest": 4.56, "published": true, "created_at": "#{time_now.to_s(Granite::DATETIME_FORMAT)}"})
     review_json = JSON.parse(json_str)
 
     review_json.is_a?(JSON::Any).should be_true
@@ -48,7 +49,7 @@ describe Granite::Base do
     review.sentiment.should eq 1.23_f32
     review.interest.should eq 4.56_f64
     review.published.should eq true
-    review.created_at.should eq Time.parse("2016-02-15 10:20:30", "%F %X")
+    review.created_at.should eq time_now
   end
 
   it "takes JSON::Any Array" do

--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -35,38 +35,6 @@ describe Granite::Base do
     t.name.should eq "Elorest"
   end
 
-  it "takes JSON::Type" do
-    tmp_hash = {} of String | Symbol => String | JSON::Type
-    body = %({
-      "name": "Elias",
-      "user_id": 333,
-      "published": false,
-      "upvotes": 9223372036854775807,
-      "sentiment": 3.14,
-      "interest": 3.92,
-      "created_at": "1900-01-01 12:10:05.123"
-    })
-
-    case json = JSON.parse_raw(body)
-    when Hash
-      json.each do |key, value|
-        tmp_hash[key.as(String)] = value
-      end
-    when Array
-      tmp_hash["_json"] = json
-    end
-
-    review = Review.new(tmp_hash)
-
-    review.name.should eq "Elias"
-    review.user_id.should eq 333_i32
-    review.published.should eq false
-    review.upvotes.should eq 9223372036854775807_i64
-    review.sentiment.should eq 3.14_f32
-    review.interest.should eq 3.92_f64
-    review.created_at.should eq Time.parse("1900-01-01 12:10:05.123", "%F %X")
-  end
-
   it "takes JSON::Any" do
     json_str = %({"name": "json::anyReview", "user_id": 99, "upvotes": 2, "sentiment": 1.23, "interest": 4.56, "published": true, "created_at": "2016-02-15 10:20:30"})
     review_json = JSON.parse(json_str)

--- a/src/granite.cr
+++ b/src/granite.cr
@@ -1,4 +1,10 @@
 require "yaml"
 require "db"
+
+module Granite
+  DATETIME_FORMAT = "%F %X%z"
+end
+
 require "./granite/base"
 require "./query_builder"
+

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -43,7 +43,7 @@ class Granite::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, String | JSON::Type))
+  def initialize(args : Hash(Symbol | String, String | JSON::Any))
     set_attributes(args)
   end
 

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -60,7 +60,7 @@ module Granite::Fields
       parsed_params = [] of DB::Any
       {% for name, options in CONTENT_FIELDS %}
         {% if options[:type].id == Time.id %}
-          parsed_params << {{name.id}}.try(&.to_s("%F %X"))
+          parsed_params << {{name.id}}.try(&.to_s(Granite::DATETIME_FORMAT))
         {% else %}
           parsed_params << {{name.id}}
         {% end %}
@@ -74,7 +74,7 @@ module Granite::Fields
       {% for name, options in FIELDS %}
         {% type = options[:type] %}
         {% if type.id == Time.id %}
-          fields["{{name}}"] = {{name.id}}.try(&.to_s("%F %X"))
+          fields["{{name}}"] = {{name.id}}.try(&.to_s(Granite::DATETIME_FORMAT))
         {% elsif type.id == Slice.id %}
           fields["{{name}}"] = {{name.id}}.try(&.to_s(""))
         {% else %}
@@ -91,7 +91,7 @@ module Granite::Fields
           {% type = options[:type] %}
           %field, %value = "{{name.id}}", {{name.id}}
           {% if type.id == Time.id %}
-            json.field %field, %value.try(&.to_s("%F %X"))
+            json.field %field, %value.try(&.to_s(Granite::DATETIME_FORMAT))
           {% elsif type.id == Slice.id %}
             json.field %field, %value.id.try(&.to_s(""))
           {% else %}
@@ -144,7 +144,7 @@ module Granite::Fields
               if value.is_a?(Time)
                  @{{_name.id}} = value
                elsif value.to_s =~ TIME_FORMAT_REGEX
-                 @{{_name.id}} = Time.parse(value.to_s, "%F %X")
+                 @{{_name.id}} = Time.parse(value.to_s, Granite::DATETIME_FORMAT)
                end
             {% else %}
               @{{_name.id}} = value.is_a?(JSON::Any) ? value.as_s : value.to_s

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -1,7 +1,7 @@
 require "json"
 
 module Granite::Fields
-  alias Type = JSON::Type | DB::Any | JSON::Any
+  alias Type = DB::Any | JSON::Any
   TIME_FORMAT_REGEX = /\d{4,}-\d{2,}-\d{2,}\s\d{2,}:\d{2,}:\d{2,}/
 
   macro included
@@ -101,10 +101,14 @@ module Granite::Fields
       end
     end
 
-    def set_attributes(args : Hash(String | Symbol, Type) | JSON::Any)
+    def set_attributes(args : Hash(String | Symbol, Type))
       args.each do |k, v|
         cast_to_field(k, v.as(Type))
       end
+    end
+
+    def set_attributes(attributes : JSON::Any)
+      set_attributes(attributes.as_h)
     end
 
     def set_attributes(**args)

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -23,7 +23,7 @@ module Granite::Querying
             if @@adapter.class.name == "Granite::Adapter::Sqlite"
               # sqlite3 does not have timestamp type - timestamps are stored as str
               # will break for null timestamps
-              self.\{{name.id}} = Time.parse(result.read(String), "%F %X" )
+              self.\{{name.id}} = Time.parse(result.read(String), Granite::DATETIME_FORMAT)
             else
               self.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
             end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -13,7 +13,7 @@ module Granite::Transactions
 
     def from_json(args : JSON::Any)
       if args.as_a?
-        args.map { |a| model = new; model.set_attributes(a); model }
+        args.as_a.map { |a| model = new; model.set_attributes(a); model }
       else
         model = new
         model.set_attributes(args)


### PR DESCRIPTION
Minimally addresses issues required to update Granite to Crystal 0.25.0

- [x]  Update Dockerfile since `crystal deps` is being removed. https://github.com/crystal-lang/crystal/pull/5544
- [x]  Remove references of `JSON::Type`. https://github.com/crystal-lang/crystal/pull/5183
- [x] `File.stat` is renamed to `File.info` https://github.com/crystal-lang/crystal/pull/5584
- [x] Update all instances of `Time::Kind` to use the new `Time::Location` instead

Read the changelog for anything I missed. https://github.com/bcardiff/crystal/blob/changelog/0.25.0/CHANGELOG.md

Fixes #226