### PR TITLE
Further update Granite to be compatible with Crystal 0.25

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -16,11 +16,11 @@ dependencies:
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.4.0
+    version: ~> 0.5.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.9.0
+    version: ~> 0.10.0
 
   pg:
     github: will/crystal-pg

--- a/spec/granite/querying/from_sql_spec.cr
+++ b/spec/granite/querying/from_sql_spec.cr
@@ -1,14 +1,6 @@
 require "../../spec_helper"
 
 macro build_review_emitter(driver)
-  {%
-    timestamp = if driver == "sqlite"
-                  "Time.now.to_s(Granite::DATETIME_FORMAT)".id
-                else
-                  "Time.now".id
-                end
-  %}
-
   FieldEmitter.new.tap do |e|
     e._set_values(
       [
@@ -19,7 +11,7 @@ macro build_review_emitter(driver)
         nil,   # sentiment
         nil,   # interest
         true,  # published
-        {{ timestamp }} # created_at
+        Time.now, # created_at
       ]
     )
   end

--- a/spec/granite/transactions/import_spec.cr
+++ b/spec/granite/transactions/import_spec.cr
@@ -6,6 +6,7 @@ module {{adapter.capitalize.id}}
     describe "using the defualt primary key" do
       context "with an AUTO INCREMENT PK" do
         it "should import 3 new objects" do
+          Parent.clear
           to_import = [
             Parent.new(name: "ImportParent1"),
             Parent.new(name: "ImportParent2"),

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -81,9 +81,9 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       model_array.each do |model|
         model.set_timestamps
         next unless model.valid?
-        stmt << '('
+        stmt << "("
         stmt << Array.new(fields.size, '?').join(',')
-        params.concat fields.map { |field| model.to_h[field] }
+        params.concat fields.map { |field| model.read_attribute field }
         stmt << "),"
       end
     end.chomp(',')

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -70,7 +70,6 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
-    now = Time.utc_now
 
     statement = String.build do |stmt|
       stmt << "INSERT"
@@ -80,8 +79,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       stmt << ") VALUES "
 
       model_array.each do |model|
-        model.updated_at = now if model.responds_to? :updated_at
-        model.created_at = now if model.responds_to? :created_at
+        model.set_timestamps
         next unless model.valid?
         stmt << '('
         stmt << Array.new(fields.size, '?').join(',')

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -88,7 +88,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
         next unless model.valid?
         stmt << '('
         stmt << fields.map_with_index { |_f, idx| "$#{index + idx + 1}" }.join(',')
-        params.concat fields.map { |field| model.to_h[field] }
+        params.concat fields.map { |field| model.read_attribute field }
         stmt << "),"
         index += fields.size
       end

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -71,7 +71,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
-    now = Time.utc_now
+    now = Time.utc_now.at_beginning_of_second
     # PG fails when inserting null into AUTO INCREMENT PK field.
     # If AUTO INCREMENT is TRUE AND all model's pk are nil, remove PK from fields list for AUTO INCREMENT to work properly
     fields.reject! { |field| field == primary_name } if model_array.all? { |m| m.to_h[primary_name].nil? } && auto == "true"
@@ -84,8 +84,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << ") VALUES "
 
       model_array.each do |model|
-        model.updated_at = now if model.responds_to? :updated_at
-        model.created_at = now if model.responds_to? :created_at
+        model.set_timestamps
         next unless model.valid?
         stmt << '('
         stmt << fields.map_with_index { |_f, idx| "$#{index + idx + 1}" }.join(',')

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -87,7 +87,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
         model.set_timestamps
         stmt << '('
         stmt << Array.new(fields.size, '?').join(',')
-        params.concat fields.map { |field| model.to_h[field] }
+        params.concat fields.map { |field| model.read_attribute field }
         stmt << "),"
       end
     end.chomp(',')

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -46,7 +46,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
   end
-  
+
   def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
@@ -70,7 +70,6 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
     params = [] of DB::Any
-    now = Time.now.to_utc
 
     statement = String.build do |stmt|
       stmt << "INSERT "
@@ -85,8 +84,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
       model_array.each do |model|
         next unless model.valid?
-        model.updated_at = now if model.responds_to? :updated_at
-        model.created_at = now if model.responds_to? :created_at
+        model.set_timestamps
         stmt << '('
         stmt << Array.new(fields.size, '?').join(',')
         params.concat fields.map { |field| model.to_h[field] }

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -43,7 +43,7 @@ class Granite::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, String | JSON::Any))
+  def initialize(args : Hash(Symbol | String, JSON::Any::Type))
     set_attributes(args)
   end
 

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -43,15 +43,7 @@ class Granite::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, String?))
-    set_attributes(args)
-  end
-
-  def initialize(args : Hash(Symbol | String, Granite::Fields::Type))
-    set_attributes(args)
-  end
-
-  def initialize(args : Hash(Symbol | String, JSON::Any))
+  def initialize(args : Hash(Symbol | String, DB::Any))
     set_attributes(args)
   end
 

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -43,7 +43,15 @@ class Granite::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, JSON::Any::Type))
+  def initialize(args : Hash(Symbol | String, String?))
+    set_attributes(args)
+  end
+
+  def initialize(args : Hash(Symbol | String, Granite::Fields::Type))
+    set_attributes(args)
+  end
+
+  def initialize(args : Hash(Symbol | String, JSON::Any))
     set_attributes(args)
   end
 

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -150,10 +150,10 @@ module Granite::Fields
               @{{_name.id}} = value.is_a?(JSON::Any) ? value.as_bool : ["1", "yes", "true", true].includes?(value)
             {% elsif type.id == Time.id %}
               if value.is_a?(Time)
-                 @{{_name.id}} = value
-               elsif value.to_s =~ TIME_FORMAT_REGEX
-                 @{{_name.id}} = Time.parse(value.to_s, Granite::DATETIME_FORMAT)
-               end
+                @{{_name.id}} = value
+              elsif value.to_s =~ TIME_FORMAT_REGEX
+                @{{_name.id}} = Time.parse(value.to_s, Granite::DATETIME_FORMAT)
+              end
             {% else %}
               @{{_name.id}} = value.is_a?(JSON::Any) ? value.as_s : value.to_s
             {% end %}

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -97,6 +97,18 @@ module Granite::Fields
       end
     end
 
+    def read_attribute(attribute_name : Symbol | String) : DB::Any
+      {% begin %}
+        case attribute_name.to_s
+        {% for name, options in FIELDS %}
+          when "{{ name }}" then @{{ name.id }}
+        {% end %}
+        else
+          raise "Cannot read attribute #{attribute_name}, invalid attribute"
+        end
+      {% end %}
+    end
+
     def set_attributes(args : Hash(String | Symbol, Type))
       args.each do |k, v|
         cast_to_field(k, v.as(Type))

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -59,11 +59,7 @@ module Granite::Fields
     def content_values
       parsed_params = [] of DB::Any
       {% for name, options in CONTENT_FIELDS %}
-        {% if options[:type].id == Time.id %}
-          parsed_params << {{name.id}}.try(&.to_s(Granite::DATETIME_FORMAT))
-        {% else %}
-          parsed_params << {{name.id}}
-        {% end %}
+        parsed_params << {{name.id}}
       {% end %}
       return parsed_params
     end

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -18,18 +18,7 @@ module Granite::Querying
         # Loading from DB means existing records.
         @new_record = false
         \{% for name, options in FIELDS %}
-          \{% type = options[:type] %}
-          \{% if type.id.stringify == "Time" %}
-            if @@adapter.class.name == "Granite::Adapter::Sqlite"
-              # sqlite3 does not have timestamp type - timestamps are stored as str
-              # will break for null timestamps
-              self.\{{name.id}} = Time.parse(result.read(String), Granite::DATETIME_FORMAT)
-            else
-              self.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
-            end
-          \{% else %}
-            self.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
-          \{% end %}
+          self.\{{name.id}} = result.read(Union(\{{options[:type].id}} | Nil))
         \{% end %}
         self
       end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -66,8 +66,16 @@ module Granite::Transactions
       end
     end
 
+    def set_timestamps(*, to time = Time.now, mode = :create)
+      if mode == :create
+        @created_at = time.to_utc.at_beginning_of_second
+      end
+
+      @updated_at = time.to_utc.at_beginning_of_second
+    end
+
     private def __create
-      @created_at = @updated_at = Time.now.to_utc
+      set_timestamps
       fields = self.class.content_fields.dup
       params = content_values
       if value = @{{primary_name}}
@@ -99,7 +107,7 @@ module Granite::Transactions
     end
 
     private def __update
-      @updated_at = Time.now.to_utc
+      set_timestamps mode: :update
       fields = self.class.content_fields
       params = content_values + [@{{primary_name}}]
 


### PR DESCRIPTION
The latest granite tag produces this when attempting to build amber projects which used the scaffold generator:

```
instantiating 'PostCommentController#create()'
in src/controllers/post_comment_controller.cr:22: no overload matches 'PostComment.new' with type Hash(String, String | Nil)
Overloads are:
 - Granite::Base.new(args : Hash(Symbol | String, String | JSON::Any))
 - Granite::Base.new(**args : Object)
 - Granite::Base.new()

    post_comment = PostComment.new(post_comment_params.validate!)
```

In trying to get the amber project compatible with crystal 0.25, I'd like to change this to JSON::Any::Type, which allows the generated code to compile.