### PR TITLE
Adding transaction raise methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ post = Post.find_by!(slug: "foo") # raises when no records found.
 other_post = Post.find_by(slug: "foo", type: "bar") # Also works for multiple arguments.
 ```
 
+#### Create
+```crystal
+Post.create(name: "Granite Rocks!", body: "Check this out.") # Set attributes and call save
+Post.create!(name: "Granite Rocks!", body: "Check this out.") # Set attributes and call save!. Will throw an exception when the save failed
+```
+
 #### Insert
 
 ```crystal
@@ -342,6 +348,11 @@ post = Post.new
 post.name = "Granite Rocks!"
 post.body = "Check this out."
 post.save
+
+post = Post.new
+post.name = "Granite Rocks!"
+post.body = "Check this out."
+post.save! # raises when save failed
 ```
 
 #### Update
@@ -350,6 +361,12 @@ post.save
 post = Post.find 1
 post.name = "Granite Really Rocks!"
 post.save
+
+post = Post.find 1
+post.update(name: "Granite Really Rocks!") # Assigns attributes and calls save
+
+post = Post.find 1
+post.update!(name: "Granite Really Rocks!") # Assigns attributes and calls save!. Will throw an exception when the save failed
 ```
 
 #### Delete
@@ -358,6 +375,9 @@ post.save
 post = Post.find 1
 post.destroy
 puts "deleted" unless post
+
+post = Post.find 1
+post.destroy! # raises when delete failed
 ```
 
 ### Queries
@@ -423,9 +443,9 @@ class CustomView < Granite:Base
   field commentbody : String
 
   query <<-SQL
-    SELECT articles.articlebody, comments.commentbody 
-    FROM articles 
-    JOIN comments 
+    SELECT articles.articlebody, comments.commentbody
+    FROM articles
+    JOIN comments
     ON comments.articleid = articles.id
   SQL
 end

--- a/spec/granite/exceptions/record_invalid_spec.cr
+++ b/spec/granite/exceptions/record_invalid_spec.cr
@@ -1,0 +1,24 @@
+require "../../spec_helper"
+
+class RecordInvalidParent; end
+class Granite::RecordInvalidParent; end
+
+describe Granite::RecordInvalid do
+  context "when used with an class" do
+    it "should have an message" do
+      Granite::RecordInvalid
+        .new(RecordInvalidParent.name)
+        .message
+        .should eq("Could not process RecordInvalidParent")
+    end
+  end
+
+  context "when used with an module" do
+    it "should have an message" do
+      Granite::RecordInvalid
+        .new(Granite::RecordInvalidParent.name)
+        .message
+        .should eq("Could not process Granite::RecordInvalidParent")
+    end
+  end
+end

--- a/spec/granite/exceptions/record_invalid_spec.cr
+++ b/spec/granite/exceptions/record_invalid_spec.cr
@@ -1,24 +1,27 @@
 require "../../spec_helper"
 
-class RecordInvalidParent; end
-class Granite::RecordInvalidParent; end
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe Granite::RecordNotSaved do
+    it "should have a message" do
+      parent = Parent.new
+      parent.save
 
-describe Granite::RecordInvalid do
-  context "when used with an class" do
-    it "should have an message" do
-      Granite::RecordInvalid
-        .new(RecordInvalidParent.name)
+      Granite::RecordNotSaved
+        .new(Parent.name, parent)
         .message
-        .should eq("Could not process RecordInvalidParent")
+        .should eq("Could not process {{adapter.capitalize.id}}::Parent")
     end
-  end
 
-  context "when used with an module" do
-    it "should have an message" do
-      Granite::RecordInvalid
-        .new(Granite::RecordInvalidParent.name)
-        .message
-        .should eq("Could not process Granite::RecordInvalidParent")
+    it "should have a model" do
+      parent = Parent.new
+      parent.save
+
+      Granite::RecordNotSaved
+        .new(Parent.name, parent)
+        .model
+        .should eq(parent)
     end
   end
 end
+{% end %}

--- a/spec/granite/exceptions/record_not_destroyed_spec.cr
+++ b/spec/granite/exceptions/record_not_destroyed_spec.cr
@@ -1,0 +1,24 @@
+require "../../spec_helper"
+
+class RecordNotDestroyedParent; end
+class Granite::RecordNotDestroyedParent; end
+
+describe Granite::RecordNotDestroyed do
+  context "when used with an class" do
+    it "should have an message" do
+      Granite::RecordNotDestroyed
+        .new(RecordNotDestroyedParent.name)
+        .message
+        .should eq("Could not destroy RecordNotDestroyedParent")
+    end
+  end
+
+  context "when used with an module" do
+    it "should have an message" do
+      Granite::RecordNotDestroyed
+        .new(Granite::RecordNotDestroyedParent.name)
+        .message
+        .should eq("Could not destroy Granite::RecordNotDestroyedParent")
+    end
+  end
+end

--- a/spec/granite/exceptions/record_not_destroyed_spec.cr
+++ b/spec/granite/exceptions/record_not_destroyed_spec.cr
@@ -1,24 +1,27 @@
 require "../../spec_helper"
 
-class RecordNotDestroyedParent; end
-class Granite::RecordNotDestroyedParent; end
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe Granite::RecordNotDestroyed do
+    it "should have a message" do
+      parent = Parent.new
+      parent.save
 
-describe Granite::RecordNotDestroyed do
-  context "when used with an class" do
-    it "should have an message" do
       Granite::RecordNotDestroyed
-        .new(RecordNotDestroyedParent.name)
+        .new(Parent.name, parent)
         .message
-        .should eq("Could not destroy RecordNotDestroyedParent")
+        .should eq("Could not destroy {{adapter.capitalize.id}}::Parent")
     end
-  end
 
-  context "when used with an module" do
-    it "should have an message" do
+    it "should have a model" do
+      parent = Parent.new
+      parent.save
+
       Granite::RecordNotDestroyed
-        .new(Granite::RecordNotDestroyedParent.name)
-        .message
-        .should eq("Could not destroy Granite::RecordNotDestroyedParent")
+        .new(Parent.name, parent)
+        .model
+        .should eq(parent)
     end
   end
 end
+{% end %}

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -72,5 +72,19 @@ module {{adapter.capitalize.id}}
       end
     end
   end
+
+  describe "{{ adapter.id }} .create!" do
+    it "creates a new object" do
+      parent = Parent.create!(name: "Test Parent")
+      parent.id.should_not be_nil
+      parent.name.should eq("Test Parent")
+    end
+
+    it "does not create an invalid object but raise an exception" do
+      expect_raises(Granite::Transactions::TransactionFailed) do
+        parent = Parent.create!(name: "")
+      end
+    end
+  end
 end
 {% end %}

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -81,7 +81,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "does not create an invalid object but raise an exception" do
-      expect_raises(Granite::Transactions::TransactionFailed) do
+      expect_raises(Granite::Transactions::TransactionError) do
         parent = Parent.create!(name: "")
       end
     end

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -5,13 +5,13 @@ module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} .create" do
     it "creates a new object" do
       parent = Parent.create(name: "Test Parent")
-      parent.id.should_not be_nil
+      parent.persisted?.should be_true
       parent.name.should eq("Test Parent")
     end
 
     it "does not create an invalid object" do
       parent = Parent.create(name: "")
-      parent.id.should be_nil
+      parent.persisted?.should be_false
     end
 
     it "takes JSON::Any" do
@@ -51,7 +51,7 @@ module {{adapter.capitalize.id}}
     describe "with a custom primary key" do
       it "creates a new object" do
         school = School.create(name: "Test School")
-        school.custom_id.should_not be_nil
+        school.persisted?.should be_true
         school.name.should eq("Test School")
       end
     end
@@ -59,7 +59,7 @@ module {{adapter.capitalize.id}}
     describe "with a modulized model" do
       it "creates a new object" do
         county = Nation::County.create(name: "Test School")
-        county.id.should_not be_nil
+        county.persisted?.should be_true
         county.name.should eq("Test School")
       end
     end
@@ -76,12 +76,12 @@ module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} .create!" do
     it "creates a new object" do
       parent = Parent.create!(name: "Test Parent")
-      parent.id.should_not be_nil
+      parent.persisted?.should be_true
       parent.name.should eq("Test Parent")
     end
 
     it "does not create an invalid object but raise an exception" do
-      expect_raises(Granite::Transactions::TransactionError) do
+      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
         parent = Parent.create!(name: "")
       end
     end

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -80,8 +80,8 @@ module {{adapter.capitalize.id}}
       parent.name.should eq("Test Parent")
     end
 
-    it "does not create an invalid object but raise an exception" do
-      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
+    it "does not save but raise an exception" do
+      expect_raises(Granite::RecordNotSaved, "{{adapter.capitalize.id}}::Parent") do
         parent = Parent.create!(name: "")
       end
     end

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -56,6 +56,17 @@ module {{adapter.capitalize.id}}
     end
   end
 
+  class ParentWithCallback < Granite::Base
+    adapter {{ adapter.id }}
+    table_name parents
+
+    before_destroy :cancel_destroy
+
+    private def cancel_destroy
+      abort!("Canceling destroy")
+    end
+  end
+
   describe "{{ adapter.id }} #destroy!" do
     it "destroys an object" do
       parent = Parent.new
@@ -69,9 +80,9 @@ module {{adapter.capitalize.id}}
     end
 
     it "does not destroy an invalid object but raise an exception" do
-      parent = Parent.new
+      parent = ParentWithCallback.new
 
-      expect_raises(Granite::Transactions::TransactionError) do
+      expect_raises(Granite::RecordNotDestroyed, "{{adapter.capitalize.id}}::Parent") do
         parent.destroy!
       end
     end

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -73,7 +73,7 @@ module {{adapter.capitalize.id}}
       callback_with_abort.name = "DestroyRaisesException"
       callback_with_abort.abort_at = "temp"
       callback_with_abort.do_abort = false
-      callback_with_abort.save
+      callback_with_abort.save!
       callback_with_abort.abort_at = "before_destroy"
       callback_with_abort.do_abort = true
 

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -71,9 +71,10 @@ module {{adapter.capitalize.id}}
     it "does not destroy an invalid object but raise an exception" do
       callback_with_abort = CallbackWithAbort.new
       callback_with_abort.name = "DestroyRaisesException"
-      callback_with_abort.abort_at = "before_destroy"
+      callback_with_abort.abort_at = "temp"
       callback_with_abort.do_abort = false
-      callback_with_abort.save!
+      callback_with_abort.save
+      callback_with_abort.abort_at = "before_destroy"
       callback_with_abort.do_abort = true
 
 

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -55,5 +55,26 @@ module {{adapter.capitalize.id}}
       end
     end
   end
+
+  describe "{{ adapter.id }} #destroy!" do
+    it "destroys an object" do
+      parent = Parent.new
+      parent.name = "Test Parent"
+      parent.save
+
+      id = parent.id
+      parent.destroy
+      found = Parent.find id
+      found.should be_nil
+    end
+
+    it "does not destroy an invalid object but raise an exception" do
+      parent = Parent.new
+
+      expect_raises(Granite::Transactions::TransactionFailed) do
+        parent.destroy!
+      end
+    end
+  end
 end
 {% end %}

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -68,7 +68,7 @@ module {{adapter.capitalize.id}}
       found.should be_nil
     end
 
-    it "does not destroy an invalid object but raise an exception" do
+    it "does not destroy but raise an exception" do
       callback_with_abort = CallbackWithAbort.new
       callback_with_abort.name = "DestroyRaisesException"
       callback_with_abort.abort_at = "temp"

--- a/spec/granite/transactions/destroy_spec.cr
+++ b/spec/granite/transactions/destroy_spec.cr
@@ -71,7 +71,7 @@ module {{adapter.capitalize.id}}
     it "does not destroy an invalid object but raise an exception" do
       parent = Parent.new
 
-      expect_raises(Granite::Transactions::TransactionFailed) do
+      expect_raises(Granite::Transactions::TransactionError) do
         parent.destroy!
       end
     end

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -144,7 +144,7 @@ module {{adapter.capitalize.id}}
     it "does not create an invalid object but raise an exception" do
       parent = Parent.new
 
-      expect_raises(Granite::Transactions::TransactionFailed) do
+      expect_raises(Granite::Transactions::TransactionError) do
         parent.save!
       end
     end

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -7,14 +7,14 @@ module {{adapter.capitalize.id}}
       parent = Parent.new
       parent.name = "Test Parent"
       parent.save
-      parent.id.should_not be_nil
+      parent.persisted?.should be_true
     end
 
     it "does not create an invalid object" do
       parent = Parent.new
       parent.name = ""
       parent.save
-      parent.id.should be_nil
+      parent.persisted?.should be_false
     end
 
     it "updates an existing object" do
@@ -96,7 +96,7 @@ module {{adapter.capitalize.id}}
         county = Nation::County.new
         county.name = "Test School"
         county.save
-        county.id.should_not be_nil
+        county.persisted?.should be_true
       end
 
       it "updates an existing object" do
@@ -138,7 +138,7 @@ module {{adapter.capitalize.id}}
       parent = Parent.new
       parent.name = "Test Parent"
       parent.save!
-      parent.id.should_not be_nil
+      parent.persisted?.should be_true
     end
 
     it "does not create an invalid object but raise an exception" do

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -144,7 +144,7 @@ module {{adapter.capitalize.id}}
     it "does not create an invalid object but raise an exception" do
       parent = Parent.new
 
-      expect_raises(Granite::Transactions::TransactionError) do
+      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
         parent.save!
       end
     end

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -141,7 +141,7 @@ module {{adapter.capitalize.id}}
       parent.id.should_not be_nil
     end
 
-    it "does not create an invalid object" do
+    it "does not create an invalid object but raise an exception" do
       parent = Parent.new
 
       expect_raises(Granite::Transactions::TransactionFailed) do

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -132,5 +132,22 @@ module {{adapter.capitalize.id}}
       end
     end
   end
+
+  describe "{{ adapter.id }} #save!" do
+    it "creates a new object" do
+      parent = Parent.new
+      parent.name = "Test Parent"
+      parent.save!
+      parent.id.should_not be_nil
+    end
+
+    it "does not create an invalid object" do
+      parent = Parent.new
+
+      expect_raises(Granite::Transactions::TransactionFailed) do
+        parent.save!
+      end
+    end
+  end
 end
 {% end %}

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -141,10 +141,10 @@ module {{adapter.capitalize.id}}
       parent.persisted?.should be_true
     end
 
-    it "does not create an invalid object but raise an exception" do
+    it "does not create but raise an exception" do
       parent = Parent.new
 
-      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
+      expect_raises(Granite::RecordNotSaved, "{{adapter.capitalize.id}}::Parent") do
         parent.save!
       end
     end

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -35,11 +35,11 @@ module {{adapter.capitalize.id}}
       Parent.find!(parent.id).name.should eq "Other parent"
     end
 
-    it "does not update an invalid object but raises an exception" do
+    it "does not update but raises an exception" do
       parent = Parent.new(name: "New Parent")
       parent.save!
 
-      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
+      expect_raises(Granite::RecordNotSaved, "{{adapter.capitalize.id}}::Parent") do
         parent.update!(name: "")
       end
 

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -9,6 +9,7 @@ module {{adapter.capitalize.id}}
 
       parent.update(name: "Other parent").should be_true
       parent.name.should eq "Other parent"
+
       Parent.find!(parent.id).name.should eq "Other parent"
     end
 
@@ -30,6 +31,7 @@ module {{adapter.capitalize.id}}
 
       parent.update!(name: "Other parent")
       parent.name.should eq "Other parent"
+
       Parent.find!(parent.id).name.should eq "Other parent"
     end
 
@@ -40,6 +42,7 @@ module {{adapter.capitalize.id}}
       expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
         parent.update!(name: "")
       end
+
       Parent.find!(parent.id).name.should eq "New Parent"
     end
   end

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -1,0 +1,47 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} #update" do
+    it "updates an object" do
+      parent = Parent.new(name: "New Parent")
+      parent.save!
+
+      parent.update(name: "Other parent").should be_true
+      parent.name.should eq "Other parent"
+      Parent.find!(parent.id).name.should eq "Other parent"
+    end
+
+    it "does not update an invalid object" do
+      parent = Parent.new(name: "New Parent")
+      parent.save!
+
+      parent.update(name: "").should be_false
+      parent.name.should eq ""
+
+      Parent.find!(parent.id).name.should eq "New Parent"
+    end
+  end
+
+  describe "{{ adapter.id }} #update!" do
+    it "updates an object" do
+      parent = Parent.new(name: "New Parent")
+      parent.save!
+
+      parent.update!(name: "Other parent")
+      parent.name.should eq "Other parent"
+      Parent.find!(parent.id).name.should eq "Other parent"
+    end
+
+    it "does not update an invalid object but raises an exception" do
+      parent = Parent.new(name: "New Parent")
+      parent.save!
+
+      expect_raises(Granite::RecordInvalid, "{{adapter.capitalize.id}}::Parent") do
+        parent.update!(name: "")
+      end
+      Parent.find!(parent.id).name.should eq "New Parent"
+    end
+  end
+end
+{% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -128,6 +128,7 @@ require "uuid"
       table_name callbacks_with_abort
       primary abort_at : String, auto: false
       field do_abort : Bool
+      field name : String
 
       property history : IO::Memory = IO::Memory.new
 

--- a/src/granite/exceptions.cr
+++ b/src/granite/exceptions.cr
@@ -1,13 +1,21 @@
 module Granite
-  class RecordInvalid < ::Exception
-    def initialize(class_name : String)
+  class RecordNotSaved < ::Exception
+    getter model : Granite::Base
+
+    def initialize(class_name : String, model : Granite::Base)
       super("Could not process #{class_name}")
+
+      @model = model
     end
   end
 
   class RecordNotDestroyed < ::Exception
-    def initialize(class_name : String)
+    getter model : Granite::Base
+
+    def initialize(class_name : String, model : Granite::Base)
       super("Could not destroy #{class_name}")
+
+      @model = model
     end
   end
 end

--- a/src/granite/exceptions.cr
+++ b/src/granite/exceptions.cr
@@ -1,12 +1,12 @@
 module Granite
   class RecordInvalid < ::Exception
-    def initialize(class_name : String | Nil)
+    def initialize(class_name : String)
       super("Could not process #{class_name}")
     end
   end
 
   class RecordNotDestroyed < ::Exception
-    def initialize(class_name : String | Nil)
+    def initialize(class_name : String)
       super("Could not destroy #{class_name}")
     end
   end

--- a/src/granite/exceptions.cr
+++ b/src/granite/exceptions.cr
@@ -1,0 +1,13 @@
+module Granite
+  class RecordInvalid < ::Exception
+    def initialize(class_name : String | Nil)
+      super("Could not process #{class_name}")
+    end
+  end
+
+  class RecordNotDestroyed < ::Exception
+    def initialize(class_name : String | Nil)
+      super("Could not destroy #{class_name}")
+    end
+  end
+end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -21,7 +21,7 @@ module Granite::Transactions
       instance = create(args)
 
       if instance.errors.any?
-        raise Granite::RecordInvalid.new(self.name)
+        raise Granite::RecordNotSaved.new(self.name, instance)
       end
 
       instance
@@ -169,7 +169,7 @@ module Granite::Transactions
 
 
     def save!
-      save || raise Granite::RecordInvalid.new(self.class.name)
+      save || raise Granite::RecordNotSaved.new(self.class.name, self)
     end
 
     def update(**args)
@@ -209,7 +209,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      destroy || raise Granite::RecordNotDestroyed.new(self.class.name)
+      destroy || raise Granite::RecordNotDestroyed.new(self.class.name, self)
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -1,4 +1,6 @@
 module Granite::Transactions
+  class TransactionFailed < Exception; end
+
   module ClassMethods
     def create(**args)
       create(args.to_h)
@@ -141,6 +143,11 @@ module Granite::Transactions
         return false
       end
       true
+    end
+
+
+    def save!
+      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.class.to_s}")
     end
 
     # Destroy will remove this from the database.

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -14,11 +14,11 @@ module Granite::Transactions
     end
 
     def create!(**args)
-      create(args.to_h) || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+      create(args.to_h).id.nil? || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
     end
 
     def create!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
-      create(args) || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+      create(args).id.nil? || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
     end
 
     def from_json(args : JSON::Any)

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -164,6 +164,26 @@ module Granite::Transactions
       save || raise Granite::RecordInvalid.new(self.class.name)
     end
 
+    def update(**args)
+      update(args.to_h)
+    end
+
+    def update(args : Hash(Symbol | String, DB::Any) | JSON::Any)
+      set_attributes(args)
+
+      save
+    end
+
+    def update!(**args)
+      update!(args.to_h)
+    end
+
+    def update!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
+      set_attributes(args)
+
+      save!
+    end
+
     # Destroy will remove this from the database.
     def destroy
       begin

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -1,6 +1,6 @@
-module Granite::Transactions
-  class TransactionError < Exception; end
+require "./exceptions"
 
+module Granite::Transactions
   module ClassMethods
     def create(**args)
       create(args.to_h)
@@ -20,8 +20,8 @@ module Granite::Transactions
     def create!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
       instance = create(args)
 
-      if !instance.errors.empty?
-        raise TransactionError.new("Could not create #{self.name}")
+      if instance.errors.any?
+        raise Granite::RecordInvalid.new(self.name)
       end
 
       instance
@@ -161,7 +161,7 @@ module Granite::Transactions
 
 
     def save!
-      save || raise Granite::Transactions::TransactionError.new("Could not save #{self.name}")
+      save || raise Granite::RecordInvalid.new(self.class.name)
     end
 
     # Destroy will remove this from the database.
@@ -181,7 +181,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      destroy || raise Granite::Transactions::TransactionError.new("Could not destroy #{self.name}")
+      destroy || raise Granite::RecordNotDestroyed.new(self.class.name)
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -13,6 +13,14 @@ module Granite::Transactions
       instance
     end
 
+    def create!(**args)
+      create(args.to_h) || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+    end
+
+    def create!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
+      create(args) || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+    end
+
     def from_json(args : JSON::Any)
       if args.as_a?
         args.as_a.map { |a| model = new; model.set_attributes(a); model }
@@ -167,7 +175,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.class.to_s}")
+      save || raise Granite::Transactions::TransactionFailed.new("Could not destroy #{self.class.to_s}")
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -165,6 +165,10 @@ module Granite::Transactions
       end
       true
     end
+
+    def destroy!
+      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.class.to_s}")
+    end
   end
 
   # Returns true if this object hasn't been saved yet.

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -181,7 +181,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      save || raise Granite::Transactions::TransactionError.new("Could not destroy #{self.name}")
+      destroy || raise Granite::Transactions::TransactionError.new("Could not destroy #{self.name}")
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -1,5 +1,5 @@
 module Granite::Transactions
-  class TransactionFailed < Exception; end
+  class TransactionError < Exception; end
 
   module ClassMethods
     def create(**args)
@@ -20,7 +20,9 @@ module Granite::Transactions
     def create!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
       instance = create(args)
 
-      raise Granite::Transactions::TransactionFailed.new("Could not create #{self.name}") unless instance.errors.empty?
+      if !instance.errors.empty?
+        raise TransactionError.new("Could not create #{self.name}")
+      end
 
       instance
     end
@@ -159,7 +161,7 @@ module Granite::Transactions
 
 
     def save!
-      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.name}")
+      save || raise Granite::Transactions::TransactionError.new("Could not save #{self.name}")
     end
 
     # Destroy will remove this from the database.
@@ -179,7 +181,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      save || raise Granite::Transactions::TransactionFailed.new("Could not destroy #{self.name}")
+      save || raise Granite::Transactions::TransactionError.new("Could not destroy #{self.name}")
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -14,11 +14,15 @@ module Granite::Transactions
     end
 
     def create!(**args)
-      create(args.to_h).id.nil? || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+      create!(args.to_h)
     end
 
     def create!(args : Hash(Symbol | String, DB::Any) | JSON::Any)
-      create(args).id.nil? || raise Granite::Transactions::TransactionFailed.new("Could not create #{self.class.to_s}")
+      instance = create(args)
+
+      raise Granite::Transactions::TransactionFailed.new("Could not create #{self.name}") unless instance.errors.empty?
+
+      instance
     end
 
     def from_json(args : JSON::Any)
@@ -155,7 +159,7 @@ module Granite::Transactions
 
 
     def save!
-      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.class.to_s}")
+      save || raise Granite::Transactions::TransactionFailed.new("Could not save #{self.name}")
     end
 
     # Destroy will remove this from the database.
@@ -175,7 +179,7 @@ module Granite::Transactions
     end
 
     def destroy!
-      save || raise Granite::Transactions::TransactionFailed.new("Could not destroy #{self.class.to_s}")
+      save || raise Granite::Transactions::TransactionFailed.new("Could not destroy #{self.name}")
     end
   end
 


### PR DESCRIPTION
<h1>What is done</h1>
Added "helper" methods that raises exceptions on errors. The idea is that sometimes you want to be sure that an transaction method has succeeded. If the method did not complete successfully than it will raise an exception.

<h1>Methods</h1>

- Added update method that accepts args that will set the attributes of the model and tries to save it
- Added update! method that accepts args that will set the attribute of the model and tries to save! it
- Added save! method that will call the save method and raises an exception if it failed
- Added create! method that will call the create method and raises an exception if it failed
- Added destroy! method that will call the destroy method and raises an exception if it failed
- Added custom exceptions for the methods so an application developer is able to catch specific errors
