### PR TITLE
Adds dev dep on envy for .env loading/parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,8 +762,7 @@ $ docker-compose down
 If you'd like to test without docker you can do so by following the instructions below:
 
 1. Install dependencies with `$ crystal deps`
-2. Update .env to use appropriate ENV variables, or create appropriate databases.
-3. Setup databases:
+2. Create appropriate databases:
 
 #### PostgreSQL
 
@@ -785,5 +784,4 @@ CREATE DATABASE granite_db;
 GRANT ALL PRIVILEGES ON granite_db.* TO 'granite'@'localhost' WITH GRANT OPTION;
 ```
 
-4. Export `.env` with `$ source .env`
-5. `$ crystal spec`
+3. `$ crystal spec`

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ $ docker-compose down
 
 If you'd like to test without docker you can do so by following the instructions below:
 
-1. Install dependencies with `$ crystal deps`
+1. Install dependencies with `$ shards install`
 2. Create appropriate databases:
 
 #### PostgreSQL

--- a/shard.yml
+++ b/shard.yml
@@ -14,6 +14,9 @@ dependencies:
     version: ~> 0.5.0
 
 development_dependencies:
+  envy:
+    github: petoem/envy
+
   mysql:
     github: crystal-lang/crystal-mysql
     version: ~> 0.5.0

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,6 @@
+require "envy"
+Envy.load
+
 require "spec"
 
 module GraniteExample


### PR DESCRIPTION
Currently the docs say "source the .env file to add the variables to your shell". This makes that step unnecessary because envy does that automatically.