### PR TITLE
fix conflicting use of query

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ post = Post.all("ORDER BY posts.name DESC LIMIT 1").first
 
 #### Customizing SELECT
 
-The `query` macro allows you to customize the entire query, including the SELECT portion.  This shouldn't be necessary in most cases, but allows you to craft more complex (i.e. cross-table) queries if needed:
+The `select_statement` macro allows you to customize the entire query, including the SELECT portion.  This shouldn't be necessary in most cases, but allows you to craft more complex (i.e. cross-table) queries if needed:
 
 ```crystal
 class CustomView < Granite:Base
@@ -442,7 +442,7 @@ class CustomView < Granite:Base
   field articlebody : String
   field commentbody : String
 
-  query <<-SQL
+  select_statement <<-SQL
     SELECT articles.articlebody, comments.commentbody
     FROM articles
     JOIN comments

--- a/spec/granite/querying/passthrough_spec.cr
+++ b/spec/granite/querying/passthrough_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} #query" do
+    it "calls query against the db driver" do
+     Parent.clear
+     Parent.query "SELECT name FROM parents" do |rs|
+        rs.column_name(0).should eq "name"
+       end
+    end
+  end
+
+  describe "{{ adapter.id }} #scalar" do
+    it "calls scalar against the db driver" do
+     Parent.clear
+     Parent.scalar "SELECT count(*) FROM parents" do |total|
+       total.should eq 0
+     end
+    end
+  end
+
+  describe "{{ adapter.id }} #exec" do
+    it "calls exec against the db driver" do
+     Parent.clear
+     Parent.exec "SELECT count(*) FROM parents"
+    end
+  end
+end
+{% end %}

--- a/spec/granite/querying/passthrough_spec.cr
+++ b/spec/granite/querying/passthrough_spec.cr
@@ -19,12 +19,5 @@ module {{adapter.capitalize.id}}
      end
     end
   end
-
-  describe "{{ adapter.id }} #exec" do
-    it "calls exec against the db driver" do
-     Parent.clear
-     Parent.exec "SELECT count(*) FROM parents"
-    end
-  end
 end
 {% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -235,7 +235,7 @@ require "uuid"
       field articlebody : String
       field commentbody : String
 
-      query <<-SQL
+      select_statement <<-SQL
         SELECT articles.id, articles.articlebody, comments.commentbody FROM articles JOIN comments ON comments.articleid = articles.id
       SQL
     end

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -7,7 +7,7 @@ module Granite::Select
     end
   end
 
-  macro query(text)
+  macro select_statement(text)
     @@select.custom = {{text.strip}}
 
     def self.select


### PR DESCRIPTION
renamed the macro to `select_statement` so it won't conflict with the pass-through `query` method.  fixed #246 