### PR TITLE
Optionally add nodoc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,7 +116,7 @@ end
 
 ### Generating Documentation
 
-By default, running `crystal docs` will include Granite methods, constants, and properties.  To exclude these, have an ENV variable: `DISABLE_GRANTE_DOCS=true` set before running `crystal docs`.
+By default, running `crystal docs` will include Granite methods, constants, and properties.  To exclude these, have an ENV variable: `DISABLE_GRANITE_DOCS=true` set before running `crystal docs`.
 
 The `field` and `primary` macros have a comment option that will specify the documentation comment to apply to that property's getter and setter.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,7 +83,7 @@ end
 
 This will override the default primary key of `id : Int64`.
 
-#### Natural Keys
+### Natural Keys
 
 For natural keys, you can set `auto: false` option to disable auto increment.
 
@@ -95,7 +95,7 @@ class Site < Granite::Base
 end
 ```
 
-#### UUIDs
+### UUIDs
 
 For databases that utilize UUIDs as the primary key, the `primary` macro can be used again with the `auto: false` option.  A `before_create` callback can be added to the model to randomly generate and set a secure UUID on the record before it is saved to the database.
 
@@ -114,6 +114,13 @@ class Book < Granite::Base
 end
 ```
 
+### Generating Documentation
+
+By default, running `crystal docs` will include Granite methods, constants, and properties.  To exclude these, have an ENV variable: `DISABLE_GRANTE_DOCS=true` set before running `crystal docs`.
+
+The `field` and `primary` macros have a comment option that will specify the documentation comment to apply to that property's getter and setter.
+
+`field age : Int32, comment: "# Number of seconds since the post was posted"`
 
 
 See the [Docs folder](./) for additional information.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,11 +116,10 @@ end
 
 ### Generating Documentation
 
-By default, running `crystal docs` will include Granite methods, constants, and properties.  To exclude these, have an ENV variable: `DISABLE_GRANITE_DOCS=true` set before running `crystal docs`.
+By default, running `crystal docs` will **not** include Granite methods, constants, and properties.  To include these, have an ENV variable: `DISABLE_GRANITE_DOCS=false` set before running `crystal docs`.
 
 The `field` and `primary` macros have a comment option that will specify the documentation comment to apply to that property's getter and setter.
 
 `field age : Int32, comment: "# Number of seconds since the post was posted"`
-
 
 See the [Docs folder](./) for additional information.

--- a/src/granite/callbacks.cr
+++ b/src/granite/callbacks.cr
@@ -9,13 +9,13 @@ module Granite::Callbacks
 
   macro included
     macro inherited
-      noDoc CALLBACKS = {
+      disable_granite_docs? CALLBACKS = {
         {% for name in CALLBACK_NAMES %}
           {{name.id}}: [] of Nil,
         {% end %}
       }
       {% for name in CALLBACK_NAMES %}
-        noDoc def {{name.id}}
+        disable_granite_docs? def {{name.id}}
           __{{name.id}}
         end
       {% end %}

--- a/src/granite/callbacks.cr
+++ b/src/granite/callbacks.cr
@@ -9,13 +9,13 @@ module Granite::Callbacks
 
   macro included
     macro inherited
-      CALLBACKS = {
+      noDoc CALLBACKS = {
         {% for name in CALLBACK_NAMES %}
           {{name.id}}: [] of Nil,
         {% end %}
       }
       {% for name in CALLBACK_NAMES %}
-        def {{name.id}}
+        noDoc def {{name.id}}
           __{{name.id}}
         end
       {% end %}

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -6,8 +6,8 @@ module Granite::Fields
 
   macro included
     macro inherited
-      CONTENT_FIELDS = {} of Nil => Nil
-      FIELDS = {} of Nil => Nil
+      noDoc CONTENT_FIELDS = {} of Nil => Nil
+      noDoc FIELDS = {} of Nil => Nil
     end
   end
 
@@ -36,30 +36,34 @@ module Granite::Fields
     {% end %}
 
     # Create the properties
+
     {% for name, options in FIELDS %}
       {% type = options[:type] %}
       {% suffixes = options[:raise_on_nil] ? ["?", ""] : ["", "!"] %}
       {% if options[:json_options] %}
          @[JSON::Field({{**options[:json_options]}})]
       {% end %}
+      {% if options[:comment] %}
+         {{options[:comment].id}}
+      {% end %}
       property{{suffixes[0].id}} {{name.id}} : Union({{type.id}} | Nil)
-      def {{name.id}}{{suffixes[1].id}}
+      noDoc def {{name.id}}{{suffixes[1].id}}
         raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
         @{{name.id}}.not_nil!
       end
     {% end %}
 
     # keep a hash of the fields to be used for mapping
-    def self.fields : Array(String)
+    noDoc def self.fields : Array(String)
       @@fields ||= {{ FIELDS.empty? ? "[] of String".id : FIELDS.keys.map(&.id.stringify) }}
     end
 
-    def self.content_fields : Array(String)
+    noDoc def self.content_fields : Array(String)
       @@content_fields ||= {{ CONTENT_FIELDS.empty? ? "[] of String".id : CONTENT_FIELDS.keys.map(&.id.stringify) }}
     end
 
     # keep a hash of the params that will be passed to the adapter.
-    def content_values
+    noDoc def content_values
       parsed_params = [] of DB::Any
       {% for name, options in CONTENT_FIELDS %}
         parsed_params << {{name.id}}
@@ -67,7 +71,7 @@ module Granite::Fields
       return parsed_params
     end
 
-    def to_h
+    noDoc def to_h
       fields = {} of String => DB::Any
 
       {% for name, options in FIELDS %}
@@ -84,7 +88,7 @@ module Granite::Fields
       return fields
     end
 
-    def read_attribute(attribute_name : Symbol | String) : DB::Any
+    noDoc def read_attribute(attribute_name : Symbol | String) : DB::Any
       {% begin %}
         case attribute_name.to_s
         {% for name, options in FIELDS %}
@@ -96,13 +100,13 @@ module Granite::Fields
       {% end %}
     end
 
-    def set_attributes(args : Hash(String | Symbol, Type))
+    noDoc def set_attributes(args : Hash(String | Symbol, Type))
       args.each do |k, v|
         cast_to_field(k, v.as(Type))
       end
     end
 
-    def set_attributes(**args)
+    noDoc def set_attributes(**args)
       set_attributes(args.to_h)
     end
 

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -6,8 +6,8 @@ module Granite::Fields
 
   macro included
     macro inherited
-      noDoc CONTENT_FIELDS = {} of Nil => Nil
-      noDoc FIELDS = {} of Nil => Nil
+      disable_granite_docs? CONTENT_FIELDS = {} of Nil => Nil
+      disable_granite_docs? FIELDS = {} of Nil => Nil
     end
   end
 
@@ -47,23 +47,23 @@ module Granite::Fields
          {{options[:comment].id}}
       {% end %}
       property{{suffixes[0].id}} {{name.id}} : Union({{type.id}} | Nil)
-      noDoc def {{name.id}}{{suffixes[1].id}}
+      disable_granite_docs? def {{name.id}}{{suffixes[1].id}}
         raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
         @{{name.id}}.not_nil!
       end
     {% end %}
 
     # keep a hash of the fields to be used for mapping
-    noDoc def self.fields : Array(String)
+    disable_granite_docs? def self.fields : Array(String)
       @@fields ||= {{ FIELDS.empty? ? "[] of String".id : FIELDS.keys.map(&.id.stringify) }}
     end
 
-    noDoc def self.content_fields : Array(String)
+    disable_granite_docs? def self.content_fields : Array(String)
       @@content_fields ||= {{ CONTENT_FIELDS.empty? ? "[] of String".id : CONTENT_FIELDS.keys.map(&.id.stringify) }}
     end
 
     # keep a hash of the params that will be passed to the adapter.
-    noDoc def content_values
+    disable_granite_docs? def content_values
       parsed_params = [] of DB::Any
       {% for name, options in CONTENT_FIELDS %}
         parsed_params << {{name.id}}
@@ -71,7 +71,7 @@ module Granite::Fields
       return parsed_params
     end
 
-    noDoc def to_h
+    disable_granite_docs? def to_h
       fields = {} of String => DB::Any
 
       {% for name, options in FIELDS %}
@@ -88,7 +88,7 @@ module Granite::Fields
       return fields
     end
 
-    noDoc def read_attribute(attribute_name : Symbol | String) : DB::Any
+    disable_granite_docs? def read_attribute(attribute_name : Symbol | String) : DB::Any
       {% begin %}
         case attribute_name.to_s
         {% for name, options in FIELDS %}
@@ -100,13 +100,13 @@ module Granite::Fields
       {% end %}
     end
 
-    noDoc def set_attributes(args : Hash(String | Symbol, Type))
+    disable_granite_docs? def set_attributes(args : Hash(String | Symbol, Type))
       args.each do |k, v|
         cast_to_field(k, v.as(Type))
       end
     end
 
-    noDoc def set_attributes(**args)
+    disable_granite_docs? def set_attributes(**args)
       set_attributes(args.to_h)
     end
 

--- a/src/granite/migrator.cr
+++ b/src/granite/migrator.cr
@@ -42,7 +42,7 @@ module Granite::Migrator
     {% klass = @type.name %}
     {% adapter = "#{klass}.adapter".id %}
 
-    noDoc class Migrator < Granite::Migrator::Base
+    disable_granite_docs? class Migrator < Granite::Migrator::Base
       def drop
         {{klass}}.exec "DROP TABLE IF EXISTS #{ @quoted_table_name };"
       end
@@ -85,7 +85,7 @@ module Granite::Migrator
       end
     end
 
-    noDoc def self.migrator(**args)
+    disable_granite_docs? def self.migrator(**args)
       Migrator.new(self, **args)
     end
   end

--- a/src/granite/migrator.cr
+++ b/src/granite/migrator.cr
@@ -42,7 +42,7 @@ module Granite::Migrator
     {% klass = @type.name %}
     {% adapter = "#{klass}.adapter".id %}
 
-    class Migrator < Granite::Migrator::Base
+    noDoc class Migrator < Granite::Migrator::Base
       def drop
         {{klass}}.exec "DROP TABLE IF EXISTS #{ @quoted_table_name };"
       end
@@ -85,7 +85,7 @@ module Granite::Migrator
       end
     end
 
-    def self.migrator(**args)
+    noDoc def self.migrator(**args)
       Migrator.new(self, **args)
     end
   end

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -8,13 +8,13 @@ module Granite::Querying
       \{% primary_type = PRIMARY[:type] %}
 
       # Create the from_sql method
-      noDoc def self.from_sql(result)
+      disable_granite_docs? def self.from_sql(result)
         model = \{{@type.name.id}}.new
         model.set_attributes(result)
         model
       end
 
-      noDoc def set_attributes(result : DB::ResultSet)
+      disable_granite_docs? def set_attributes(result : DB::ResultSet)
         # Loading from DB means existing records.
         @new_record = false
         \{% for name, options in FIELDS %}

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -8,13 +8,13 @@ module Granite::Querying
       \{% primary_type = PRIMARY[:type] %}
 
       # Create the from_sql method
-      def self.from_sql(result)
+      noDoc def self.from_sql(result)
         model = \{{@type.name.id}}.new
         model.set_attributes(result)
         model
       end
 
-      def set_attributes(result : DB::ResultSet)
+      noDoc def set_attributes(result : DB::ResultSet)
         # Loading from DB means existing records.
         @new_record = false
         \{% for name, options in FIELDS %}

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -1,6 +1,6 @@
 # Adds a :nodoc: to granite methods/constants if `DISABLE_GRANTE_DOCS` ENV var is true
-macro noDoc(stmt)
-  {% if env("DISABLE_GRANTE_DOCS") == "true" %}
+macro disable_granite_docs?(stmt)
+  {% unless env("DISABLE_GRANITE_DOCS") == "false" %}
     # :nodoc:
     {{stmt.id}}
   {% else %}
@@ -11,8 +11,8 @@ end
 module Granite::Table
   macro included
     macro inherited
-      noDoc SETTINGS = {} of Nil => Nil
-      noDoc PRIMARY = {name: id, type: Int64, auto: true}
+      disable_granite_docs? SETTINGS = {} of Nil => Nil
+      disable_granite_docs? PRIMARY = {name: id, type: Int64, auto: true}
     end
   end
 
@@ -21,7 +21,7 @@ module Granite::Table
   macro adapter(name)
     @@adapter = Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
 
-    noDoc def self.adapter
+    disable_granite_docs? def self.adapter
       @@adapter
     end
   end
@@ -71,27 +71,27 @@ module Granite::Table
     @@primary_auto = "{{primary_auto}}"
     @@primary_type = "{{primary_type}}"
 
-    noDoc def self.table_name
+    disable_granite_docs? def self.table_name
       @@table_name
     end
 
-    noDoc def self.primary_name
+    disable_granite_docs? def self.primary_name
       @@primary_name
     end
 
-    noDoc def self.primary_type
+    disable_granite_docs? def self.primary_type
       @@primary_type
     end
 
-    noDoc def self.primary_auto
+    disable_granite_docs? def self.primary_auto
       @@primary_auto
     end
 
-    noDoc def self.quoted_table_name
+    disable_granite_docs? def self.quoted_table_name
       @@adapter.quote(table_name)
     end
 
-    noDoc def self.quote(column_name)
+    disable_granite_docs? def self.quote(column_name)
       @@adapter.quote(column_name)
     end
   end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -1,8 +1,18 @@
+# Adds a :nodoc: to granite methods/constants if `DISABLE_GRANTE_DOCS` ENV var is true
+macro noDoc(stmt)
+  {% if env("DISABLE_GRANTE_DOCS") == "true" %}
+    # :nodoc:
+    {{stmt.id}}
+  {% else %}
+    {{stmt.id}}
+  {% end %}
+end
+
 module Granite::Table
   macro included
     macro inherited
-      SETTINGS = {} of Nil => Nil
-      PRIMARY = {name: id, type: Int64, auto: true}
+      noDoc SETTINGS = {} of Nil => Nil
+      noDoc PRIMARY = {name: id, type: Int64, auto: true}
     end
   end
 
@@ -11,7 +21,7 @@ module Granite::Table
   macro adapter(name)
     @@adapter = Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
 
-    def self.adapter
+    noDoc def self.adapter
       @@adapter
     end
   end
@@ -27,11 +37,26 @@ module Granite::Table
     {% PRIMARY[:type] = decl.type %}
   end
 
+  # specify the primary key column and type and comment
+  macro primary(decl, comment)
+    {% PRIMARY[:name] = decl.var %}
+    {% PRIMARY[:type] = decl.type %}
+    {% PRIMARY[:comment] = comment %}
+  end
+
   # specify the primary key column and type and auto_increment
   macro primary(decl, auto)
     {% PRIMARY[:name] = decl.var %}
     {% PRIMARY[:type] = decl.type %}
     {% PRIMARY[:auto] = auto %}
+  end
+
+  # specify the primary key column and type and auto_increment and comment
+  macro primary(decl, comment, auto)
+    {% PRIMARY[:name] = decl.var %}
+    {% PRIMARY[:type] = decl.type %}
+    {% PRIMARY[:auto] = auto %}
+    {% PRIMARY[:comment] = comment %}
   end
 
   macro __process_table
@@ -46,27 +71,27 @@ module Granite::Table
     @@primary_auto = "{{primary_auto}}"
     @@primary_type = "{{primary_type}}"
 
-    def self.table_name
+    noDoc def self.table_name
       @@table_name
     end
 
-    def self.primary_name
+    noDoc def self.primary_name
       @@primary_name
     end
 
-    def self.primary_type
+    noDoc def self.primary_type
       @@primary_type
     end
 
-    def self.primary_auto
+    noDoc def self.primary_auto
       @@primary_auto
     end
 
-    def self.quoted_table_name
+    noDoc def self.quoted_table_name
       @@adapter.quote(table_name)
     end
 
-    def self.quote(column_name)
+    noDoc def self.quote(column_name)
       @@adapter.quote(column_name)
     end
   end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -2,22 +2,22 @@ require "./exceptions"
 
 module Granite::Transactions
   module ClassMethods
-    def create(**args)
+    noDoc def create(**args)
       create(args.to_h)
     end
 
-    def create(args : Hash(Symbol | String, DB::Any))
+    noDoc def create(args : Hash(Symbol | String, DB::Any))
       instance = new
       instance.set_attributes(args)
       instance.save
       instance
     end
 
-    def create!(**args)
+    noDoc def create!(**args)
       create!(args.to_h)
     end
 
-    def create!(args : Hash(Symbol | String, DB::Any))
+    noDoc def create!(args : Hash(Symbol | String, DB::Any))
       instance = create(args)
 
       if instance.errors.any?
@@ -39,7 +39,7 @@ module Granite::Transactions
     # The import class method will run a batch INSERT statement for each model in the array
     # the array must contain only one model class
     # invalid model records will be skipped
-    def self.import(model_array : Array(self) | Granite::Collection(self), batch_size : Int32 = model_array.size)
+    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -50,7 +50,7 @@ module Granite::Transactions
       end
     end
 
-    def self.import(model_array : Array(self) | Granite::Collection(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
+    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -61,7 +61,7 @@ module Granite::Transactions
       end
     end
 
-    def self.import(model_array : Array(self) | Granite::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
+    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -72,7 +72,7 @@ module Granite::Transactions
       end
     end
 
-    def set_timestamps(*, to time = Time.now, mode = :create)
+    noDoc def set_timestamps(*, to time = Time.now, mode = :create)
       if mode == :create
         @created_at = time.to_utc.at_beginning_of_second
       end
@@ -132,7 +132,7 @@ module Granite::Transactions
     # The save method will check to see if the primary exists yet. If it does it
     # will call the update method, otherwise it will call the create method.
     # This will update the timestamps appropriately.
-    def save
+    noDoc def save
       return false unless valid?
 
       begin
@@ -158,32 +158,32 @@ module Granite::Transactions
     end
 
 
-    def save!
+    noDoc def save!
       save || raise Granite::RecordNotSaved.new(self.class.name, self)
     end
 
-    def update(**args)
+    noDoc def update(**args)
       update(args.to_h)
     end
 
-    def update(args : Hash(Symbol | String, DB::Any))
+    noDoc def update(args : Hash(Symbol | String, DB::Any))
       set_attributes(args)
 
       save
     end
 
-    def update!(**args)
+    noDoc def update!(**args)
       update!(args.to_h)
     end
 
-    def update!(args : Hash(Symbol | String, DB::Any))
+    noDoc def update!(args : Hash(Symbol | String, DB::Any))
       set_attributes(args)
 
       save!
     end
 
     # Destroy will remove this from the database.
-    def destroy
+    noDoc def destroy
       begin
         __before_destroy
         __destroy
@@ -198,7 +198,7 @@ module Granite::Transactions
       true
     end
 
-    def destroy!
+    noDoc def destroy!
       destroy || raise Granite::RecordNotDestroyed.new(self.class.name, self)
     end
   end
@@ -212,7 +212,7 @@ module Granite::Transactions
   getter? destroyed : Bool = false
 
   # Returns true if the record is persisted.
-  def persisted?
+  noDoc def persisted?
     !(new_record? || destroyed?)
   end
 end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -2,22 +2,22 @@ require "./exceptions"
 
 module Granite::Transactions
   module ClassMethods
-    noDoc def create(**args)
+    disable_granite_docs? def create(**args)
       create(args.to_h)
     end
 
-    noDoc def create(args : Hash(Symbol | String, DB::Any))
+    disable_granite_docs? def create(args : Hash(Symbol | String, DB::Any))
       instance = new
       instance.set_attributes(args)
       instance.save
       instance
     end
 
-    noDoc def create!(**args)
+    disable_granite_docs? def create!(**args)
       create!(args.to_h)
     end
 
-    noDoc def create!(args : Hash(Symbol | String, DB::Any))
+    disable_granite_docs? def create!(args : Hash(Symbol | String, DB::Any))
       instance = create(args)
 
       if instance.errors.any?
@@ -39,7 +39,7 @@ module Granite::Transactions
     # The import class method will run a batch INSERT statement for each model in the array
     # the array must contain only one model class
     # invalid model records will be skipped
-    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), batch_size : Int32 = model_array.size)
+    disable_granite_docs? def self.import(model_array : Array(self) | Granite::Collection(self), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -50,7 +50,7 @@ module Granite::Transactions
       end
     end
 
-    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
+    disable_granite_docs? def self.import(model_array : Array(self) | Granite::Collection(self), update_on_duplicate : Bool, columns : Array(String), batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -61,7 +61,7 @@ module Granite::Transactions
       end
     end
 
-    noDoc def self.import(model_array : Array(self) | Granite::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
+    disable_granite_docs? def self.import(model_array : Array(self) | Granite::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
       begin
         fields_duplicate = fields.dup
         model_array.each_slice(batch_size, true) do |slice|
@@ -72,7 +72,7 @@ module Granite::Transactions
       end
     end
 
-    noDoc def set_timestamps(*, to time = Time.now, mode = :create)
+    disable_granite_docs? def set_timestamps(*, to time = Time.now, mode = :create)
       if mode == :create
         @created_at = time.to_utc.at_beginning_of_second
       end
@@ -132,7 +132,7 @@ module Granite::Transactions
     # The save method will check to see if the primary exists yet. If it does it
     # will call the update method, otherwise it will call the create method.
     # This will update the timestamps appropriately.
-    noDoc def save
+    disable_granite_docs? def save
       return false unless valid?
 
       begin
@@ -158,32 +158,32 @@ module Granite::Transactions
     end
 
 
-    noDoc def save!
+    disable_granite_docs? def save!
       save || raise Granite::RecordNotSaved.new(self.class.name, self)
     end
 
-    noDoc def update(**args)
+    disable_granite_docs? def update(**args)
       update(args.to_h)
     end
 
-    noDoc def update(args : Hash(Symbol | String, DB::Any))
+    disable_granite_docs? def update(args : Hash(Symbol | String, DB::Any))
       set_attributes(args)
 
       save
     end
 
-    noDoc def update!(**args)
+    disable_granite_docs? def update!(**args)
       update!(args.to_h)
     end
 
-    noDoc def update!(args : Hash(Symbol | String, DB::Any))
+    disable_granite_docs? def update!(args : Hash(Symbol | String, DB::Any))
       set_attributes(args)
 
       save!
     end
 
     # Destroy will remove this from the database.
-    noDoc def destroy
+    disable_granite_docs? def destroy
       begin
         __before_destroy
         __destroy
@@ -198,7 +198,7 @@ module Granite::Transactions
       true
     end
 
-    noDoc def destroy!
+    disable_granite_docs? def destroy!
       destroy || raise Granite::RecordNotDestroyed.new(self.class.name, self)
     end
   end
@@ -212,7 +212,7 @@ module Granite::Transactions
   getter? destroyed : Bool = false
 
   # Returns true if the record is persisted.
-  noDoc def persisted?
+  disable_granite_docs? def persisted?
     !(new_record? || destroyed?)
   end
 end

--- a/src/granite/validators.cr
+++ b/src/granite/validators.cr
@@ -23,19 +23,19 @@ module Granite::Validators
     macro inherited
       @@validators = Array({field: String, message: String, block: Proc(self, Bool)}).new
 
-      noDoc def self.validate(message : String, &block : self -> Bool)
+      disable_granite_docs? def self.validate(message : String, &block : self -> Bool)
         self.validate(:base, message, block)
       end
 
-      noDoc def self.validate(field : (Symbol | String), message : String, &block : self -> Bool)
+      disable_granite_docs? def self.validate(field : (Symbol | String), message : String, &block : self -> Bool)
         self.validate(field, message, block)
       end
 
-      noDoc def self.validate(message : String, block : self -> Bool)
+      disable_granite_docs? def self.validate(message : String, block : self -> Bool)
         self.validate(:base, message, block)
       end
 
-      noDoc def self.validate(field : (Symbol | String), message : String, block : self -> Bool)
+      disable_granite_docs? def self.validate(field : (Symbol | String), message : String, block : self -> Bool)
         @@validators << {field: field.to_s, message: message, block: block}
       end
     end

--- a/src/granite/validators.cr
+++ b/src/granite/validators.cr
@@ -23,19 +23,19 @@ module Granite::Validators
     macro inherited
       @@validators = Array({field: String, message: String, block: Proc(self, Bool)}).new
 
-      def self.validate(message : String, &block : self -> Bool)
+      noDoc def self.validate(message : String, &block : self -> Bool)
         self.validate(:base, message, block)
       end
 
-      def self.validate(field : (Symbol | String), message : String, &block : self -> Bool)
+      noDoc def self.validate(field : (Symbol | String), message : String, &block : self -> Bool)
         self.validate(field, message, block)
       end
 
-      def self.validate(message : String, block : self -> Bool)
+      noDoc def self.validate(message : String, block : self -> Bool)
         self.validate(:base, message, block)
       end
 
-      def self.validate(field : (Symbol | String), message : String, block : self -> Bool)
+      noDoc def self.validate(field : (Symbol | String), message : String, block : self -> Bool)
         @@validators << {field: field.to_s, message: message, block: block}
       end
     end


### PR DESCRIPTION
This PR resolves #251.

It provides the ability to skip generation of Granite methods, macros, constants etc when using `crystal docs`.  It will only _not_ include the docs when the ENV var `DISABLE_GRANITE_DOCS=true`, if it is not set, or set to false it will include the Granite stuff.

The reasoning behind this; before this change on a just primary key model:

![image](https://user-images.githubusercontent.com/12136995/43031357-2ec804ac-8c6e-11e8-8f9d-cdfa75307144.png)

There is so much here that it almost makes the docs for the user's project unusable.

The same model skipping Granite stuff:

![image](https://user-images.githubusercontent.com/12136995/43031617-f54439ee-8c72-11e8-9a7b-3119daa9947f.png)

As you may notice this also adds the ability to define a comment to use on the getter/setter of each property with the following syntax: 

`field name : String, comment: "# The name of person"`

or in this case:

`primary id : Int64, comment: "# The primary key"`