### PR TITLE
Revert `.is_a?(JSON::Any)`

### DIFF
--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -122,7 +122,7 @@ module Granite::Fields
           when "{{_name.id}}"
             if "{{_name.id}}" == "{{PRIMARY[:name]}}"
               {% if !PRIMARY[:auto] %}
-                @{{PRIMARY[:name]}} = value.is_a?(JSON::Any) ? value.raw.as({{PRIMARY[:type]}}) : value.as({{PRIMARY[:type]}})
+                @{{PRIMARY[:name]}} = value.as({{PRIMARY[:type]}})
               {% end %}
               return
             end


### PR DESCRIPTION
Missed this logic when adding JSON::Serializable support.