### PR TITLE
Example for String foreign_key

### DIFF
--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -23,6 +23,7 @@ class Post < Granite::Base
   adapter mysql
 
   belongs_to :user
+  belongs_to :user, User, user_id : String # if uuid is used as an id
 
   field title : String
   timestamps


### PR DESCRIPTION
an example of that when it is necessary to establish foreign_key instead of default Int64 on String