### PR TITLE
Reuse open database connections in adapters

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -7,14 +7,16 @@ require "db"
 abstract class Granite::Adapter::Base
   getter name : String
   getter url : String
+  private property database : DB::Database
 
   def initialize(connection_hash : NamedTuple(url: String, name: String))
     @name = connection_hash[:name]
     @url = connection_hash[:url]
+    @database = DB.open(@url)
   end
 
   def open(&block)
-    yield DB.open(@url)
+    yield database
   end
 
   def log(query : String, params = [] of String) : Nil


### PR DESCRIPTION
Totally open to feedback on this approach @drujensen, but it looks to share the open database across multiple queries fine.

Looks to resolve issue #271. 