### PR TITLE
Issue #243, implement == and <=> on base.

### DIFF
--- a/spec/granite/comparisons/comparisons_spec.cr
+++ b/spec/granite/comparisons/comparisons_spec.cr
@@ -68,48 +68,35 @@ module {{adapter.capitalize.id}}
         review_ids.should eq(sorted)
       end
 
-      it "sorts records by other fields if the ids are the same" do
+      it "raises an exception if sorting with nil primary keys" do
         Review.clear
         reviews = [] of Review
         100.times do |num|
           review = new_review({downvotes: num})
           reviews << review
         end
-        review_downvotes = reviews.map{|review| review.downvotes.as(Int32)}.sort
-        sorted = reviews.shuffle.sort.map(&.downvotes)
-        review_downvotes.should eq(sorted)
+        expect_raises(Exception) do
+          sorted = reviews.shuffle.sort
+        end
       end
 
     end
 
     describe "<=>" do
-      it "compares records by id before other attributes" do
+      it "compares records with primary keys" do
         r1 = create_review({downvotes: 50})
         r2 = create_review({downvotes: 10})
-        (r1 <=> r2 < 0).should be_truthy
+        (r1 <=> r2 < 0).should_not eq(0)
       end
 
-      it "compares other fields if the ids are the same" do
-        r1 = new_review({downvotes: 50})
-        r2 = new_review({downvotes: 10})
-        (r1 <=> r2 > 0).should be_truthy
+      it "raises an exception if comparing a record without a primary key" do
+        r1 = new_review
+        r2 = create_review
+        expect_raises(Exception) do
+          r1 <=> r2
+        end
       end
 
-      it "compares Bool fields" do
-        r1 = create_review({published: true})
-        r2 = create_review({published: false})
-        (r1 <=> r2).should_not eq(0)
-      end
-
-      it "compares belongs_to field ids" do
-        teacher_1 = Teacher.create(name: "Test Teacher")
-        teacher_2 = Teacher.create(name: "Test Teacher")
-        klass_1 = Klass.new(name: "Test Class")
-        klass_1.teacher = teacher_1
-        klass_2 = Klass.new(name: "Test Class")
-        klass_2.teacher = teacher_2
-        (klass_1 <=> klass_2).should_not eq(0)
-      end
     end
   end
 end

--- a/spec/granite/comparisons/comparisons_spec.cr
+++ b/spec/granite/comparisons/comparisons_spec.cr
@@ -19,66 +19,98 @@ module {{adapter.capitalize.id}}
     review
   end
 
-  describe "{{ adapter.id }} ==" do
-    it "should correctly compare two identical reviews" do
-      r1 = new_review
-      r2 = new_review
-      (r1 == r2).should be_truthy
+  describe "{{ adapter.id }} Granite::Base" do
+
+    describe "==" do
+      it "correctly compares two identical reviews" do
+        r1 = new_review
+        r2 = new_review
+        (r1 == r2).should be_truthy
+      end
+
+      it "correctly compares two identical records with different ids" do
+        r1 = create_review
+        r2 = create_review
+        (r1 == r2).should_not be_truthy
+      end
+
+      it "correctly compares two almost identical records (1)" do
+        r1 = new_review({name: "Test"})
+        r2 = new_review({name: "Test 2"})
+        (r1 == r2).should_not be_truthy
+      end
+
+      it "correctly compares two almose identical records (2)" do
+        r1 = new_review({published: true})
+        r2 = new_review({published: false})
+        (r1 == r2).should_not be_truthy
+      end
+
+      it "correctly compares two record objects found by the same id" do
+        base_review = create_review
+        r1 = Review.find!(base_review.id)
+        r2 = Review.find!(base_review.id)
+        (r1 == r2).should be_truthy
+      end
     end
 
-    it "should correctly compare two identical records with different ids" do
-      r1 = create_review
-      r2 = create_review
-      (r1 == r2).should_not be_truthy
+    describe "sort" do
+
+      it "sorts records by id if all other fields are the same" do
+        Review.clear
+        reviews = [] of Review
+        100.times do
+          review = create_review
+          reviews << review
+        end
+        review_ids = reviews.map{|review| review.id.as(Int64)}.sort
+        sorted = reviews.shuffle.sort.map(&.id)
+        review_ids.should eq(sorted)
+      end
+
+      it "sorts records by other fields if the ids are the same" do
+        Review.clear
+        reviews = [] of Review
+        100.times do |num|
+          review = new_review({downvotes: num})
+          reviews << review
+        end
+        review_downvotes = reviews.map{|review| review.downvotes.as(Int32)}.sort
+        sorted = reviews.shuffle.sort.map(&.downvotes)
+        review_downvotes.should eq(sorted)
+      end
+
     end
 
-    it "should correctly compare two almost identical records (1)" do
-      r1 = new_review({name: "Test"})
-      r2 = new_review({name: "Test 2"})
-      (r1 == r2).should_not be_truthy
-    end
+    describe "<=>" do
+      it "compares records by id before other attributes" do
+        r1 = create_review({downvotes: 50})
+        r2 = create_review({downvotes: 10})
+        (r1 <=> r2 < 0).should be_truthy
+      end
 
-    it "should correctly compare two almose identical records (2)" do
-      r1 = new_review({published: true})
-      r2 = new_review({published: false})
-      (r1 == r2).should_not be_truthy
-    end
+      it "compares other fields if the ids are the same" do
+        r1 = new_review({downvotes: 50})
+        r2 = new_review({downvotes: 10})
+        (r1 <=> r2 > 0).should be_truthy
+      end
 
-    it "should correctly compare two review objects found by id" do
-      base_review = create_review
-      r1 = Review.find!(base_review.id)
-      r2 = Review.find!(base_review.id)
-      (r1 == r2).should be_truthy
+      it "compares Bool fields" do
+        r1 = create_review({published: true})
+        r2 = create_review({published: false})
+        (r1 <=> r2).should_not eq(0)
+      end
+
+      it "compares belongs_to field ids" do
+        teacher_1 = Teacher.create(name: "Test Teacher")
+        teacher_2 = Teacher.create(name: "Test Teacher")
+        klass_1 = Klass.new(name: "Test Class")
+        klass_1.teacher = teacher_1
+        klass_2 = Klass.new(name: "Test Class")
+        klass_2.teacher = teacher_2
+        (klass_1 <=> klass_2).should_not eq(0)
+      end
     end
   end
-
-  describe "{{ adapter.id }} sort" do
-
-    it "should sort records by id if all other fields are the same" do
-      Review.clear
-      reviews = [] of Review
-      100.times do
-        review = create_review
-        reviews << review
-      end
-      review_ids = reviews.map{|review| review.id.as(Int64)}.sort
-      sorted = reviews.shuffle.sort.map(&.id)
-      review_ids.should eq(sorted)
-    end
-
-    it "should sort records by other fields if the ids are the same" do
-      Review.clear
-      reviews = [] of Review
-      100.times do |num|
-        review = new_review({downvotes: num})
-        reviews << review
-      end
-      review_downvotes = reviews.map{|review| review.downvotes.as(Int32)}.sort
-      sorted = reviews.shuffle.sort.map(&.downvotes)
-      review_downvotes.should eq(sorted)
-    end
-
-  end
-
 end
 {% end %}

--- a/spec/granite/comparisons/comparisons_spec.cr
+++ b/spec/granite/comparisons/comparisons_spec.cr
@@ -1,0 +1,84 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+
+  def self.new_review(attributes = {} of Symbol | String => DB::Any)
+    attrs = {
+      name: "Basic Review",
+      downvotes: 10,
+      upvotes: 20_i64,
+      published: true
+    }.to_h.merge(attributes.to_h)
+    Review.new(attrs)
+  end
+
+  def self.create_review(attributes = {} of Symbol | String => DB::Any)
+    review = new_review(attributes.to_h)
+    review.save!
+    review
+  end
+
+  describe "{{ adapter.id }} ==" do
+    it "should correctly compare two identical reviews" do
+      r1 = new_review
+      r2 = new_review
+      (r1 == r2).should be_truthy
+    end
+
+    it "should correctly compare two identical records with different ids" do
+      r1 = create_review
+      r2 = create_review
+      (r1 == r2).should_not be_truthy
+    end
+
+    it "should correctly compare two almost identical records (1)" do
+      r1 = new_review({name: "Test"})
+      r2 = new_review({name: "Test 2"})
+      (r1 == r2).should_not be_truthy
+    end
+
+    it "should correctly compare two almose identical records (2)" do
+      r1 = new_review({published: true})
+      r2 = new_review({published: false})
+      (r1 == r2).should_not be_truthy
+    end
+
+    it "should correctly compare two review objects found by id" do
+      base_review = create_review
+      r1 = Review.find!(base_review.id)
+      r2 = Review.find!(base_review.id)
+      (r1 == r2).should be_truthy
+    end
+  end
+
+  describe "{{ adapter.id }} sort" do
+
+    it "should sort records by id if all other fields are the same" do
+      Review.clear
+      reviews = [] of Review
+      100.times do
+        review = create_review
+        reviews << review
+      end
+      review_ids = reviews.map{|review| review.id.as(Int64)}.sort
+      sorted = reviews.shuffle.sort.map(&.id)
+      review_ids.should eq(sorted)
+    end
+
+    it "should sort records by other fields if the ids are the same" do
+      Review.clear
+      reviews = [] of Review
+      100.times do |num|
+        review = new_review({downvotes: num})
+        reviews << review
+      end
+      review_downvotes = reviews.map{|review| review.downvotes.as(Int32)}.sort
+      sorted = reviews.shuffle.sort.map(&.downvotes)
+      review_downvotes.should eq(sorted)
+    end
+
+  end
+
+end
+{% end %}

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -13,6 +13,7 @@ require "./migrator"
 require "./select"
 require "./version"
 require "./adapters"
+require "./comparator"
 
 # Granite::Base is the base class for your model objects.
 class Granite::Base
@@ -25,6 +26,7 @@ class Granite::Base
   include ValidationHelpers
   include Migrator
   include Select
+  include Comparator
 
   include JSON::Serializable
   include YAML::Serializable
@@ -40,6 +42,7 @@ class Granite::Base
       __process_querying
       __process_transactions
       __process_migrator
+      __process_comparator
     end
   end
 

--- a/src/granite/comparator.cr
+++ b/src/granite/comparator.cr
@@ -1,0 +1,37 @@
+# Adds equals, hash, and comparison methods to Granite::Base objects.
+module Granite::Comparator
+
+  macro __process_comparator
+
+    def_equals_and_hash {{ *FIELDS.keys }}
+
+    # Compares this {{@type}} to another {{@type}} by comparing their fields in this order: {{ FIELDS.keys.join(", ").id }}.
+    # 
+    # Each individual field will be compared using the <=> (if available).
+    #
+    # Returns 0 if the two objects are equal, a negative number if this object is considered less than other, or a positive number otherwise.
+    def <=>(other : {{@type}})
+      {% for field, options in FIELDS %}
+        if self.{{field}} && !other.{{field}}
+          return -1
+        elsif !self.{{field}} && other.{{field}}
+          return 1
+        elsif self.{{field}} != other.{{field}}
+          {% 
+            type = options[:type]
+            type_node = options[:type].resolve
+          %}
+          {% if type_node.has_method?("<=>") %}
+            n = self.{{field}}.as({{type}}) <=> other.{{field}}.as({{type}})
+            return n unless n == 0
+          {% end %}
+        end
+      {% end %}
+      0
+    end
+
+    include Comparable(self)
+
+  end
+
+end

--- a/src/granite/comparator.cr
+++ b/src/granite/comparator.cr
@@ -1,12 +1,11 @@
 # Adds equals, hash, and comparison methods to Granite::Base objects.
 module Granite::Comparator
-
   macro __process_comparator
 
     def_equals_and_hash {{ *FIELDS.keys }}
 
     # Compares this {{@type}} to another {{@type}} by comparing their fields in this order: {{ FIELDS.keys.join(", ").id }}.
-    # 
+    #
     # Each individual field will be compared using the <=> (if available).
     #
     # Returns 0 if the two objects are equal, a negative number if this object is considered less than other, or a positive number otherwise.
@@ -17,7 +16,7 @@ module Granite::Comparator
         elsif !self.{{field}} && other.{{field}}
           return 1
         elsif self.{{field}} != other.{{field}}
-          {% 
+          {%
             type = options[:type]
             type_node = options[:type].resolve
           %}
@@ -33,5 +32,4 @@ module Granite::Comparator
     include Comparable(self)
 
   end
-
 end


### PR DESCRIPTION
This seemed like a good first issue to tackle ( #243 ).

This implements == and <=> by comparing the fields defined in `FIELDS`.

One limitation my implementation has is that it will not compare fields whose type does not implement `<=>` itself. I think this decision makes sense (how else would you compare those fields?), but it probably should be mentioned somewhere in the docs.

That being said, if a field's type does not have a `<=>` method, it will just _safely_ skip checking that field.

I have also added in a new set of unit tests for this feature.

I'm still fairly new to Crystal (and Amber/Granite), so please let me know if I did anything unusual and/or if there is anything that could be done in an better way.