### PR TITLE
Dj/lazy load connection

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -7,12 +7,14 @@ require "db"
 abstract class Granite::Adapter::Base
   getter name : String
   getter url : String
-  private property database : DB::Database
 
   def initialize(connection_hash : NamedTuple(url: String, name: String))
     @name = connection_hash[:name]
     @url = connection_hash[:url]
-    @database = DB.open(@url)
+  end
+
+  def database
+    @database ||= DB.open(@url)
   end
 
   def open(&block)

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -7,6 +7,7 @@ require "db"
 abstract class Granite::Adapter::Base
   getter name : String
   getter url : String
+  private property _database : DB::Database?
 
   def initialize(connection_hash : NamedTuple(url: String, name: String))
     @name = connection_hash[:name]
@@ -14,7 +15,7 @@ abstract class Granite::Adapter::Base
   end
 
   def database : DB::Database
-    @database ||= DB.open(@url)
+    @_database ||= DB.open(@url)
   end
 
   def open(&block)

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -13,7 +13,7 @@ abstract class Granite::Adapter::Base
     @url = connection_hash[:url]
   end
 
-  def database
+  def database : DB::Database
     @database ||= DB.open(@url)
   end
 


### PR DESCRIPTION
This pr changes the way the connection is created.  Before, the connection would be created when the Adapter is created.  This change will create the connection the first time a database connection is attempted.  Subsequent calls will use the same connection.