### PR TITLE
Clear errors before validating models

### DIFF
--- a/spec/granite/validations/validator_spec.cr
+++ b/spec/granite/validations/validator_spec.cr
@@ -58,6 +58,7 @@ require "../../spec_helper"
         subject.valid?.should eq false
       end
     end
+
     describe "validates using block without field" do
       it "returns true if passwords match" do
         subject = PasswordTest.new
@@ -71,6 +72,17 @@ require "../../spec_helper"
         subject.password = "123"
         subject.password_validation = "1234"
         subject.valid?.should eq false
+      end
+    end
+
+    describe "validates cleanly after previously failing" do
+      it "returns true if name is rectified after after failing" do
+        subject = NameTest.new
+        subject.name = ""
+        subject.valid?.should eq false
+
+        subject.name = "name"
+        subject.valid?.should eq true
       end
     end
   end

--- a/src/granite/validators.cr
+++ b/src/granite/validators.cr
@@ -43,11 +43,14 @@ module Granite::Validators
   end
 
   def valid?
+    errors.clear
+
     @@validators.each do |validator|
       unless validator[:block].call(self)
         errors << Error.new(validator[:field], validator[:message])
       end
     end
+
     errors.empty?
   end
 end


### PR DESCRIPTION
### Allow successive and independent calls to check model validity.

Currently validation checking is not independent and errors are left over from previous checks.
```
model.name = ""
model.valid? # => false, fails on validation for presence
name.name = "name"
model.valid? # => false, fails because errors are left over from previous validation
```

After this change validation checks clear previous errors before running the associated validators to add errors back onto the model.
```
model.name = ""
model.valid? # => false, fails on validation for presence
name.name = "name"
model.valid? # => true
```

This is not particularly useful for production code, but allows for more flexibility in specs.