### PR TITLE
reverse query builder

### DIFF
--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -1,14 +1,17 @@
 module Granite::Query::Assembler
   abstract class Base(Model)
+    @where : String?
+    @order : String?
+    @limit : String?
+    @offset : String?
+    @group_by : String?
+
     def initialize(@query : Builder(Model))
       @numbered_parameters = [] of DB::Any
       @aggregate_fields = [] of String
     end
 
-    def add_parameter(value : DB::Any) : String
-      @numbered_parameters << value
-      "$#{@numbered_parameters.size}"
-    end
+    abstract def add_parameter(value : DB::Any) : String
 
     def numbered_parameters
       @numbered_parameters
@@ -32,8 +35,124 @@ module Granite::Query::Assembler
       clauses.compact!.join " "
     end
 
-    abstract def count : Int64
-    abstract def first(n : Int32 = 1) : Array(Model)
-    abstract def delete
+    def where
+      return @where if @where
+
+      clauses = @query.where_fields.map do |field, value|
+        add_aggregate_field field
+
+        # TODO value is an array
+        if value.nil?
+          "#{field} IS NULL"
+        else
+          "#{field} = #{add_parameter value}"
+        end
+      end
+
+      return nil if clauses.none?
+
+      @where = "WHERE #{clauses.join " AND "}"
+    end
+
+    def order(use_default_order = true)
+      return @order if @order
+
+      order_fields = @query.order_fields
+
+      if order_fields.none?
+        if use_default_order
+          order_fields = default_order
+        else
+          return nil
+        end
+      end
+
+      order_clauses = order_fields.map do |expression|
+        add_aggregate_field expression[:field]
+
+        if expression[:direction] == Builder::Sort::Ascending
+          "#{expression[:field]} ASC"
+        else
+          "#{expression[:field]} DESC"
+        end
+      end
+
+      @order = "ORDER BY #{order_clauses.join ", "}"
+    end
+
+    def limit
+      @limit ||= if limit = @query.limit
+                   "LIMIT #{limit}"
+                 end
+    end
+
+    def offset
+      @offset ||= if offset = @query.offset
+                    "OFFSET #{offset}"
+                  end
+    end
+
+    def log(*stuff)
+    end
+
+    def default_order
+      [{field: Model.primary_name, direction: "ASC"}]
+    end
+
+    def group_by
+      @group_by ||= if @aggregate_fields.any?
+                      "GROUP BY #{@aggregate_fields.join ", "}"
+                    end
+    end
+
+    def count : Executor::Value(Model, Int64)
+      sql = build_sql do |s|
+        s << "SELECT COUNT(*)"
+        s << "FROM #{table_name}"
+        s << where
+        s << group_by
+        s << order
+      end
+
+      Executor::Value(Model, Int64).new sql, numbered_parameters, default: 0_i64
+    end
+
+    def first(n : Int32 = 1) : Executor::List(Model)
+      sql = build_sql do |s|
+        s << "SELECT #{field_list}"
+        s << "FROM #{table_name}"
+        s << where
+        s << order
+        s << "LIMIT #{n}"
+        s << offset
+      end
+
+      Executor::List(Model).new sql, numbered_parameters
+    end
+
+    def delete
+      sql = build_sql do |s|
+        s << "DELETE FROM #{table_name}"
+        s << where
+      end
+
+      log sql, numbered_parameters
+      Model.adapter.open do |db|
+        db.exec sql, numbered_parameters
+      end
+    end
+
+    def select
+      sql = build_sql do |s|
+        s << "SELECT #{field_list}"
+        s << "FROM #{table_name}"
+        s << where
+        s << order
+        s << limit
+        s << offset
+      end
+
+      Executor::List(Model).new sql, numbered_parameters
+    end
   end
 end

--- a/src/granite/query/assemblers/mysql.cr
+++ b/src/granite/query/assemblers/mysql.cr
@@ -1,10 +1,10 @@
 # Query runner which finalizes a query and runs it.
 # This will likely require adapter specific subclassing :[.
 module Granite::Query::Assembler
-  class Postgresql(Model) < Base(Model)
+  class Mysql(Model) < Base(Model)
     def add_parameter(value : DB::Any) : String
       @numbered_parameters << value
-      "$#{@numbered_parameters.size}"
+      "?"
     end
   end
 end

--- a/src/granite/query/assemblers/sqlite.cr
+++ b/src/granite/query/assemblers/sqlite.cr
@@ -1,0 +1,8 @@
+module Granite::Query::Assembler
+  class Sqlite(Model) < Base(Model)
+    def add_parameter(value : DB::Any) : String
+      @numbered_parameters << value
+      "?"
+    end
+  end
+end


### PR DESCRIPTION
Because SQL is fairly standard and the only differences are related to
param replacement, this reverses the base class to contain the main code
and moves the differences to the driver specific class.