### PR TITLE
Better UUID support

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -118,21 +118,20 @@ end
 
 ### UUIDs
 
-For databases that utilize UUIDs as the primary key, the `primary` macro can be used again with the `auto: false` option.  A `before_create` callback can be added to the model to randomly generate and set a secure UUID on the record before it is saved to the database.
+For databases that utilize UUIDs as the primary key, the `primary` macro can be used as a String type, with the `auto: :uuid` option.  This will generate a secure UUID when the model is saved.
 
 ```crystal
 class Book < Granite::Base
-  require "uuid"
   adapter mysql
-  primary ISBN : String, auto: false
+  primary isbn : String, auto: :uuid
   field name : String
-
-  before_create :assign_isbn
-
-  def assign_isbn
-    @ISBN = UUID.random.to_s
-  end
 end
+
+book = Book.new
+book.name = "Moby Dick"
+book.isbn # => nil
+book.save
+book.isbn # => RFC4122 V4 UUID string
 ```
 
 ### Generating Documentation

--- a/spec/granite/fields/uuid_spec.cr
+++ b/spec/granite/fields/uuid_spec.cr
@@ -1,7 +1,13 @@
+require "../../spec_helper"
+
 describe "UUID creation" do
-  it "correctly sets a UUID" do
-    item = Item.new(item_name: "item1")
+  it "correctly sets a RFC4122 V4 UUID on save" do
+    item = UUIDModel.new
+    item.uuid.should be_nil
     item.save
-    item.item_id.should be_a(String)
+    item.uuid.should be_a(String)
+    uuid = UUID.new item.uuid!
+    uuid.version.to_s.should eq "V4"
+    uuid.variant.to_s.should eq "RFC4122"
   end
 end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -319,6 +319,13 @@ require "uuid"
     ArrayModel.migrator.drop_and_create
   {% end %}
 
+  class UUIDModel < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name uuids
+
+    primary uuid : String, auto: :uuid
+  end
+
   module Validators
     class NilTest < Granite::Base
       adapter {{ adapter_literal }}
@@ -476,4 +483,5 @@ require "uuid"
   AfterInit.migrator.drop_and_create
   SongThread.migrator.drop_and_create
   CustomSongThread.migrator.drop_and_create
+  UUIDModel.migrator.drop_and_create
 {% end %}

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -9,6 +9,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     TYPES = {
       "AUTO_Int32" => "INT NOT NULL AUTO_INCREMENT",
       "AUTO_Int64" => "BIGINT NOT NULL AUTO_INCREMENT",
+      "UUID"       => "CHAR(36)",
       "created_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
       "updated_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
     }

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -9,6 +9,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     TYPES = {
       "AUTO_Int32"     => "SERIAL",
       "AUTO_Int64"     => "BIGSERIAL",
+      "UUID"           => "UUID",
       "created_at"     => "TIMESTAMP",
       "updated_at"     => "TIMESTAMP",
       "Array(String)"  => "TEXT[]",

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -9,6 +9,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     TYPES = {
       "AUTO_Int32" => "INTEGER NOT NULL",
       "AUTO_Int64" => "INTEGER NOT NULL",
+      "UUID"       => "CHAR(36)",
       "Int32"      => "INTEGER",
       "Int64"      => "INTEGER",
       "created_at" => "VARCHAR",

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -37,7 +37,6 @@ module Granite::Fields
     {% end %}
 
     # Create the properties
-
     {% for name, options in FIELDS %}
       {% type = options[:type] %}
       {% suffixes = options[:raise_on_nil] ? ["?", ""] : ["", "!"] %}
@@ -139,7 +138,7 @@ module Granite::Fields
             {% type = options[:type] %}
           when "{{_name.id}}"
             if "{{_name.id}}" == "{{PRIMARY[:name]}}"
-              {% if !PRIMARY[:auto] %}
+              {% unless PRIMARY[:auto] %}
                 @{{PRIMARY[:name]}} = value.as({{PRIMARY[:type]}})
               {% end %}
               return

--- a/src/granite/migrator.cr
+++ b/src/granite/migrator.cr
@@ -58,7 +58,9 @@ module Granite::Migrator
           # primary key
           k = {{adapter}}.quote("{{primary_name}}")
           v =
-            {% if primary_auto %}
+            {% if primary_auto == :uuid %}
+              resolve.call("UUID")
+            {% elsif primary_auto %}
               resolve.call("AUTO_{{primary_type.id}}")
             {% else %}
               resolve.call("{{primary_type.id}}")

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -30,7 +30,7 @@ module Granite::Table
   macro primary(decl, **options)
     {% PRIMARY[:name] = decl.var %}
     {% PRIMARY[:type] = decl.type %}
-    {% PRIMARY[:auto] = (options[:auto] == false || options[:auto] == true) ? options[:auto] : true %}
+    {% PRIMARY[:auto] = ([true, false, :uuid].includes? options[:auto]) ? options[:auto] : true %}
     {% PRIMARY[:options] = options %}
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -100,6 +100,12 @@ module Granite::Transactions
         {% elsif primary_auto == true %}
           {% raise "Failed to define #{@type.name}#save: Primary key must be Int(32|64), or set `auto: false` for natural keys.\n\n  primary #{primary_name} : #{primary_type}, auto: false\n" %}
         {% else %}
+          {% if primary_auto == :uuid %}
+            _uuid = UUID.random.to_s
+            @{{primary_name}} = _uuid
+            params << _uuid
+            fields << "{{primary_name}}"
+          {% end %}
           if @{{primary_name}}
             @@adapter.insert(@@table_name, fields, params, lastval: nil)
           else


### PR DESCRIPTION
Resolves #210 

Allows the primary macro's `auto` to take a `:uuid` option.  This will generate a secure UUID on model save.  

This is compliant with all three adapters, with MySQL and SQLite using `char(36)` datatype for migrator, while Postgres uses its native `UUID` type.