### PR TITLE
Add support for AND and OR clause

### DIFF
--- a/spec/granite/query/builder_spec.cr
+++ b/spec/granite/query/builder_spec.cr
@@ -13,6 +13,12 @@ describe Granite::Query::Builder(Model) do
     query.where_fields.should eq expected
   end
 
+  it "stores joins with where_fields" do
+    query = builder.where(:name, :like, "bob*").or(:age, :gt, 23)
+    expected = [{join: :and, field: "name", operator: :like, value: "bob*"}, {join: :or, field: "age", operator: :gt, value: 23}]
+    query.where_fields.should eq expected
+  end
+
   it "stores order fields" do
     query = builder.order(name: :desc).order(age: :asc)
     expected = [

--- a/spec/granite/query/builder_spec.cr
+++ b/spec/granite/query/builder_spec.cr
@@ -3,13 +3,13 @@ require "./spec_helper"
 describe Granite::Query::Builder(Model) do
   it "stores where_fields" do
     query = builder.where(name: "bob").where(age: 23)
-    expected = [{field: "name", operator: :eq, value: "bob"}, {field: "age", operator: :eq, value: 23}]
+    expected = [{join: :and, field: "name", operator: :eq, value: "bob"}, {join: :and, field: "age", operator: :eq, value: 23}]
     query.where_fields.should eq expected
   end
 
   it "stores operators with where_fields" do
     query = builder.where(:name, :like, "bob*").where(:age, :gt, 23)
-    expected = [{field: "name", operator: :like, value: "bob*"}, {field: "age", operator: :gt, value: 23}]
+    expected = [{join: :and, field: "name", operator: :like, value: "bob*"}, {join: :and, field: "age", operator: :gt, value: 23}]
     query.where_fields.should eq expected
   end
 

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -38,18 +38,12 @@ module Granite::Query::Assembler
     def where
       return @where if @where
 
-      first = true
-      clauses = [] of String
+      clauses = ["WHERE"]
 
       @query.where_fields.each do |expression|
         add_aggregate_field expression[:field]
 
-        if first
-          first = false
-          clauses << "WHERE"
-        else
-          clauses << expression[:join].to_s.upcase
-        end
+        clauses << expression[:join].to_s.upcase unless clauses.size == 1
 
         if expression[:value].nil?
           clauses << "#{expression[:field]} IS NULL"
@@ -58,7 +52,7 @@ module Granite::Query::Assembler
         end
       end
 
-      return nil if clauses.none?
+      return nil if clauses.size == 1
 
       @where = clauses.join(" ")
     end

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -38,19 +38,29 @@ module Granite::Query::Assembler
     def where
       return @where if @where
 
-      clauses = @query.where_fields.map do |expression|
+      first = true
+      clauses = [] of String
+
+      @query.where_fields.each do |expression|
         add_aggregate_field expression[:field]
 
-        if expression[:value].nil?
-          "#{expression[:field]} IS NULL"
+        if first
+          first = false
+          clauses << "WHERE"
         else
-          "#{expression[:field]} #{sql_operator(expression[:operator])} #{add_parameter expression[:value]}"
+          clauses << expression[:join].to_s.upcase
+        end
+
+        if expression[:value].nil?
+          clauses << "#{expression[:field]} IS NULL"
+        else
+          clauses << "#{expression[:field]} #{sql_operator(expression[:operator])} #{add_parameter expression[:value]}"
         end
       end
 
       return nil if clauses.none?
 
-      @where = "WHERE #{clauses.join " AND "}"
+      @where = clauses.join(" ")
     end
 
     def order(use_default_order = true)

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -62,7 +62,7 @@ class Granite::Query::Builder(Model)
   end
 
   def where(field : (Symbol | String), operator : Symbol, value : DB::Any)
-    and(field: field.to_s, operator: :eq, value: value)
+    and(field: field.to_s, operator: operator, value: value)
   end
 
   def and(**matches)

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -28,7 +28,7 @@ class Granite::Query::Builder(Model)
   end
 
   getter db_type : DbType
-  getter where_fields = [] of NamedTuple(field: String, operator: Symbol, value: DB::Any)
+  getter where_fields = [] of NamedTuple(join: Symbol, field: String, operator: Symbol, value: DB::Any)
   getter order_fields = [] of NamedTuple(field: String, direction: Sort)
   getter offset : Int64?
   getter limit : Int64?
@@ -55,14 +55,48 @@ class Granite::Query::Builder(Model)
 
   def where(matches)
     matches.each do |field, value|
-      @where_fields << {field: field.to_s, operator: :eq, value: value}
+      and(field: field.to_s, operator: :eq, value: value)
     end
 
     self
   end
 
   def where(field : (Symbol | String), operator : Symbol, value : DB::Any)
-    @where_fields << {field: field.to_s, operator: operator, value: value}
+    and(field: field.to_s, operator: :eq, value: value)
+  end
+
+  def and(**matches)
+    and(matches)
+  end
+
+  def and(matches)
+    matches.each do |field, value|
+      and(field: field.to_s, operator: :eq, value: value)
+    end
+
+    self
+  end
+
+  def and(field : (Symbol | String), operator : Symbol, value : DB::Any)
+    @where_fields << {join: :and, field: field.to_s, operator: operator, value: value}
+
+    self
+  end
+
+  def or(**matches)
+    or(matches)
+  end
+
+  def or(matches)
+    matches.each do |field, value|
+      or(field: field.to_s, operator: :eq, value: value)
+    end
+
+    self
+  end
+
+  def or(field : (Symbol | String), operator : Symbol, value : DB::Any)
+    @where_fields << {join: :or, field: field.to_s, operator: operator, value: value}
 
     self
   end


### PR DESCRIPTION
This adds two new methods: `and` and `or`.  

```crystal
User.where(age: 24).and(gender: "male").and(:name, :like, "joe*").or(:name, :like, "fred*")
```

The where method was modified to generate the where SQL with appropriate clauses.  Let me know if you think there is a better way to do this.

I will add specs soon.  