### PR TITLE
Fix Assembler#count

### DIFF
--- a/spec/granite/query/spec_helper.cr
+++ b/spec/granite/query/spec_helper.cr
@@ -33,5 +33,5 @@ end
 def ignore_whitespace(expected : String)
   whitespace = "\\s+"
   compiled = expected.split(/\s/).map { |s| Regex.escape s }.join(whitespace)
-  Regex.new compiled, Regex::Options::IGNORE_CASE ^ Regex::Options::MULTILINE
+  Regex.new "^\\s*#{compiled}\\s*$", Regex::Options::IGNORE_CASE ^ Regex::Options::MULTILINE
 end

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -110,7 +110,7 @@ module Granite::Query::Assembler
         s << "FROM #{table_name}"
         s << where
         s << group_by
-        s << order
+        s << order(use_default_order: false)
       end
 
       Executor::Value(Model, Int64).new sql, numbered_parameters, default: 0_i64


### PR DESCRIPTION
`Assembler#count` appends `ORDER BY id DESC` to sql unintentionally since #284.
Sorry for making this bug and here is the fix. 