### PR TITLE
Only define `updated/created_at` properties if they are wanted

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe "Granite::Base" do
   describe "JSON" do
-    describe "#from_json" do
+    describe ".from_json" do
       it "can create an object from json" do
         json_str = %({"name": "json::anyReview","upvotes": 2, "sentiment": 1.23, "interest": 4.56, "published": true})
 
@@ -79,11 +79,26 @@ describe "Granite::Base" do
       it "should serialize correctly" do
         model.to_json.should eq %({"task_name":"The Task"})
       end
+
+      context "when using timestamp fields" do
+        TodoJsonOptions.import([
+          TodoJsonOptions.new(name: "first todo", priority: 200),
+          TodoJsonOptions.new(name: "second todo", priority: 500),
+          TodoJsonOptions.new(name: "third todo", priority: 300),
+        ])
+
+        it "should serialize correctly" do
+          todos = TodoJsonOptions.order(id: :asc).select
+          todos[0].to_json.should eq %({"id":1,"task_name":"first todo","posted":"#{Time::Format::RFC_3339.format(todos[0].created_at!)}"})
+          todos[1].to_json.should eq %({"id":2,"task_name":"second todo","posted":"#{Time::Format::RFC_3339.format(todos[1].created_at!)}"})
+          todos[2].to_json.should eq %({"id":3,"task_name":"third todo","posted":"#{Time::Format::RFC_3339.format(todos[2].created_at!)}"})
+        end
+      end
     end
   end
 
   describe "YAML" do
-    describe "#from_yaml" do
+    describe ".from_yaml" do
       it "can create an object from YAML" do
         yaml_str = %(---\nname: yaml::anyReview\nupvotes: 2\nsentiment: 1.23\ninterest: 4.56\npublished: true)
 
@@ -159,6 +174,21 @@ describe "Granite::Base" do
 
       it "should serialize correctly" do
         model.to_yaml.should eq %(---\ntask_name: The Task\n)
+      end
+
+      context "when using timestamp fields" do
+        TodoYamlOptions.import([
+          TodoYamlOptions.new(name: "first todo", priority: 200),
+          TodoYamlOptions.new(name: "second todo", priority: 500),
+          TodoYamlOptions.new(name: "third todo", priority: 300),
+        ])
+
+        it "should serialize correctly" do
+          todos = TodoYamlOptions.order(id: :asc).select
+          todos[0].to_yaml.should eq %(---\nid: 1\ntask_name: first todo\nposted: #{Time::Format::YAML_DATE.format(todos[0].created_at!)}\n)
+          todos[1].to_yaml.should eq %(---\nid: 2\ntask_name: second todo\nposted: #{Time::Format::YAML_DATE.format(todos[1].created_at!)}\n)
+          todos[2].to_yaml.should eq %(---\nid: 3\ntask_name: third todo\nposted: #{Time::Format::YAML_DATE.format(todos[2].created_at!)}\n)
+        end
       end
     end
   end

--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe "Granite::Base" do
   describe "JSON" do
-    context ".from_json" do
+    describe "#from_json" do
       it "can create an object from json" do
         json_str = %({"name": "json::anyReview","upvotes": 2, "sentiment": 1.23, "interest": 4.56, "published": true})
 
@@ -42,7 +42,7 @@ describe "Granite::Base" do
       end
     end
 
-    context ".to_json" do
+    describe "#to_json" do
       it "emits nil values when told" do
         t = TodoEmitNull.new(name: "test todo", priority: 20)
         result = %({"id":null,"name":"test todo","priority":20,"created_at":null,"updated_at":null})
@@ -68,10 +68,22 @@ describe "Granite::Base" do
         collection.should eq %([{"name":"todo 1","priority":1},{"name":"todo 2","priority":2},{"name":"todo 3","priority":3}])
       end
     end
+
+    context "with json_options" do
+      model = TodoJsonOptions.from_json(%({"task_name": "The Task", "priority": 9000}))
+      it "should deserialize correctly" do
+        model.name.should eq "The Task"
+        model.priority.should be_nil
+      end
+
+      it "should serialize correctly" do
+        model.to_json.should eq %({"task_name":"The Task"})
+      end
+    end
   end
 
   describe "YAML" do
-    context ".from_yaml" do
+    describe "#from_yaml" do
       it "can create an object from YAML" do
         yaml_str = %(---\nname: yaml::anyReview\nupvotes: 2\nsentiment: 1.23\ninterest: 4.56\npublished: true)
 
@@ -111,7 +123,7 @@ describe "Granite::Base" do
       end
     end
 
-    context ".to_yaml" do
+    describe "#to_yaml" do
       it "emits nil values when told" do
         t = TodoEmitNull.new(name: "test todo", priority: 20)
         result = %(---\nid: \nname: test todo\npriority: 20\ncreated_at: \nupdated_at: \n)
@@ -135,6 +147,18 @@ describe "Granite::Base" do
 
         collection = todos.to_yaml
         collection.should eq %(---\n- name: todo 1\n  priority: 1\n- name: todo 2\n  priority: 2\n- name: todo 3\n  priority: 3\n)
+      end
+    end
+
+    context "with yaml_options" do
+      model = TodoYamlOptions.from_yaml(%(---\ntask_name: The Task\npriority: 9000))
+      it "should deserialize correctly" do
+        model.name.should eq "The Task"
+        model.priority.should be_nil
+      end
+
+      it "should serialize correctly" do
+        model.to_yaml.should eq %(---\ntask_name: The Task\n)
       end
     end
   end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -332,6 +332,8 @@ require "uuid"
 
     field name : String, json_options: {key: "task_name"}
     field priority : Int32, json_options: {ignore: true}
+    field updated_at : Time, json_options: {ignore: true}
+    field created_at : Time, json_options: {key: "posted"}
   end
 
   class TodoYamlOptions < Granite::Base
@@ -340,6 +342,8 @@ require "uuid"
 
     field name : String, yaml_options: {key: "task_name"}
     field priority : Int32, yaml_options: {ignore: true}
+    field updated_at : Time, yaml_options: {ignore: true}
+    field created_at : Time, yaml_options: {key: "posted"}
   end
 
   module Validators

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -326,6 +326,22 @@ require "uuid"
     primary uuid : String, auto: :uuid
   end
 
+  class TodoJsonOptions < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name todos_json
+
+    field name : String, json_options: {key: "task_name"}
+    field priority : Int32, json_options: {ignore: true}
+  end
+
+  class TodoYamlOptions < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name todos_yaml
+
+    field name : String, yaml_options: {key: "task_name"}
+    field priority : Int32, yaml_options: {ignore: true}
+  end
+
   module Validators
     class NilTest < Granite::Base
       adapter {{ adapter_literal }}
@@ -484,4 +500,6 @@ require "uuid"
   SongThread.migrator.drop_and_create
   CustomSongThread.migrator.drop_and_create
   UUIDModel.migrator.drop_and_create
+  TodoJsonOptions.migrator.drop_and_create
+  TodoYamlOptions.migrator.drop_and_create
 {% end %}

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -37,9 +37,6 @@ module Granite::Transactions
     {% primary_type = PRIMARY[:type] %}
     {% primary_auto = PRIMARY[:auto] %}
 
-    @updated_at : Time?
-    @created_at : Time?
-
     # The import class method will run a batch INSERT statement for each model in the array
     # the array must contain only one model class
     # invalid model records will be skipped
@@ -77,11 +74,15 @@ module Granite::Transactions
     end
 
     disable_granite_docs? def set_timestamps(*, to time = Time.now, mode = :create)
-      if mode == :create
-        @created_at = time.to_utc.at_beginning_of_second
-      end
+      {% if FIELDS.keys.stringify.includes? "created_at" %}
+        if mode == :create
+          @created_at = time.to_utc.at_beginning_of_second
+        end
+      {% end %}
 
-      @updated_at = time.to_utc.at_beginning_of_second
+      {% if FIELDS.keys.stringify.includes? "updated_at" %}
+        @updated_at = time.to_utc.at_beginning_of_second
+      {% end %}
     end
 
     private def __create


### PR DESCRIPTION
Adds specs for the `json_options` and `yaml_options` features

Also only includes `@updated_at` and `@created_at` properties if they were added via the `field` or `timestamps` macros.

This _could_ break people's apps who were using those without declaring them, maybe?  But i doubt it.