### PR TITLE
Association improvements

### DIFF
--- a/spec/granite/associations/belongs_to_spec.cr
+++ b/spec/granite/associations/belongs_to_spec.cr
@@ -89,4 +89,27 @@ describe "belongs_to" do
     book.save
     book.to_yaml.should eq %(---\nid: 5\nname: Introduction to Granite\n)
   end
+
+  it "provides a method to retrieve parent object that will raise if record is not found" do
+    book = Book.new
+    book.name = "Introduction to Granite"
+
+    expect_raises Granite::Querying::NotFound, "No Company found where id = " { book.publisher! }
+  end
+
+  it "provides the ability to use a custom primary key" do
+    courier = Courier.new
+    courier.courier_id = 139_132_751
+    courier.issuer_id = 999
+
+    service = CourierService.new
+    service.owner_id = 123_321
+    service.name = "My Service"
+    service.save
+
+    courier.service = service
+    courier.save
+
+    courier.service!.owner_id.should eq 123_321
+  end
 end

--- a/spec/granite/associations/has_many_spec.cr
+++ b/spec/granite/associations/has_many_spec.cr
@@ -163,5 +163,41 @@ describe "has_many" do
         teacher.klasses.find!(id)
       end
     end
+
+    it "should respect the current primary key" do
+      courier1 = Courier.new
+      courier1.courier_id = 1
+      courier1.issuer_id = 1
+      courier1.service_id = 1
+      courier1.save
+
+      courier2 = Courier.new
+      courier2.courier_id = 2
+      courier2.issuer_id = 2
+      courier2.service_id = 1
+      courier2.save
+
+      courier3 = Courier.new
+      courier3.courier_id = 3
+      courier3.issuer_id = 3
+      courier3.service_id = 1
+      courier3.save
+
+      service = CourierService.new
+      service.name = "My service"
+      service.owner_id = 1
+
+      couriers = service.couriers.to_a
+
+      couriers.size.should eq 3
+      couriers[0].courier_id.should eq courier1.courier_id
+      couriers[0].issuer_id.should eq courier1.issuer_id
+
+      couriers[1].courier_id.should eq courier2.courier_id
+      couriers[1].issuer_id.should eq courier2.issuer_id
+
+      couriers[2].courier_id.should eq courier3.courier_id
+      couriers[2].issuer_id.should eq courier3.issuer_id
+    end
   end
 end

--- a/spec/granite/associations/has_one_spec.cr
+++ b/spec/granite/associations/has_one_spec.cr
@@ -27,7 +27,31 @@ describe "has_one" do
     user.profile = profile
     profile.save
 
-    retrieved_profile = user.profile.not_nil!
+    retrieved_profile = user.profile!
     retrieved_profile.id.should eq profile.id
+  end
+
+  it "provides a method to retrieve associated object that will raise if record is not found" do
+    user = User.new
+    user.email = "test@domain.com"
+    user.save
+
+    expect_raises Granite::Querying::NotFound, "No Profile found where user_id = 3" { user.profile! }
+  end
+
+  it "provides the ability to use a custom primary key" do
+    courier = Courier.new
+    courier.courier_id = 139_132_750
+    courier.issuer_id = 999
+
+    character = Character.new
+    character.character_id = 999
+    character.name = "Mr Jones"
+    character.save
+
+    courier.issuer = character
+    courier.save
+
+    courier.issuer!.character_id.should eq 999
   end
 end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -106,6 +106,8 @@ require "uuid"
     adapter {{ adapter_literal }}
     table_name services
 
+    has_many :couriers, class_name: Courier, foreign_key: "service_id"
+
     primary owner_id : Int64, auto: false
     field! name : String
   end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -83,6 +83,33 @@ require "uuid"
     table_name users
   end
 
+  class Character < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name characters
+
+    primary character_id : Int32
+    field! name : String
+  end
+
+  class Courier < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name couriers
+
+    primary courier_id : Int32, auto: false
+    field! issuer_id : Int32
+
+    belongs_to service : CourierService, primary_key: "owner_id"
+    has_one issuer : Character, primary_key: "issuer_id", foreign_key: "character_id"
+  end
+
+  class CourierService < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name services
+
+    primary owner_id : Int64, auto: false
+    field! name : String
+  end
+
   class Profile < Granite::Base
     adapter {{ adapter_literal }}
     primary id : Int64
@@ -506,4 +533,7 @@ require "uuid"
   UUIDModel.migrator.drop_and_create
   TodoJsonOptions.migrator.drop_and_create
   TodoYamlOptions.migrator.drop_and_create
+  Character.migrator.drop_and_create
+  Courier.migrator.drop_and_create
+  CourierService.migrator.drop_and_create
 {% end %}

--- a/src/granite/association_collection.cr
+++ b/src/granite/association_collection.cr
@@ -7,14 +7,14 @@ class Granite::AssociationCollection(Owner, Target)
   def all(clause = "", params = [] of DB::Any)
     Target.all(
       [query, clause].join(" "),
-      [owner.id] + params
+      [owner.primary_key_value] + params
     )
   end
 
   def find_by(**args)
     Target.first(
       "#{query} AND #{args.map { |arg| "#{Target.quote(Target.table_name)}.#{Target.quote(arg.to_s)} = ?" }.join(" AND ")}",
-      [owner.id] + args.values.to_a
+      [owner.primary_key_value] + args.values.to_a
     )
   end
 
@@ -38,8 +38,8 @@ class Granite::AssociationCollection(Owner, Target)
     if through.nil?
       "WHERE #{Target.table_name}.#{@foreign_key.to_s} = ?"
     else
-      "JOIN #{through.to_s} ON #{through.to_s}.#{Target.to_s.underscore}_id = #{Target.table_name}.id " \
-      "WHERE #{through.to_s}.#{Owner.to_s.underscore}_id = ?"
+      "JOIN #{through.to_s} ON #{through.to_s}.#{Target.to_s.underscore}_id = #{Target.table_name}.#{Target.primary_name} " \
+      "WHERE #{through.to_s}.#{@foreign_key.to_s} = ?"
     end
   end
 end

--- a/src/granite/associations.cr
+++ b/src/granite/associations.cr
@@ -15,17 +15,22 @@ module Granite::Associations
       {% foreign_key = method_name + "_id" %}
       field {{foreign_key}} : Int64, json_options: {{options[:json_options]}}, yaml_options: {{options[:yaml_options]}}
     {% end %}
+    {% primary_key = options[:primary_key] || "id" %}
 
-    def {{method_name.id}} : {{class_name.id}}
-      if parent = {{class_name.id}}.find {{foreign_key}}
+    def {{method_name.id}} : {{class_name.id}}?
+      if parent = {{class_name.id}}.find_by({{primary_key.id}}: {{foreign_key.id}})
         parent
       else
         {{class_name.id}}.new
       end
     end
 
+    def {{method_name.id}}! : {{class_name.id}}
+      {{class_name.id}}.find_by!({{primary_key.id}}: {{foreign_key.id}})
+    end
+
     def {{method_name.id}}=(parent : {{class_name.id}})
-      @{{foreign_key}} = parent.id
+      @{{foreign_key.id}} = parent.{{primary_key.id}}
     end
   end
 
@@ -38,12 +43,18 @@ module Granite::Associations
       {% class_name = options[:class_name] || model.id.camelcase %}
     {% end %}
     {% foreign_key = options[:foreign_key] || @type.stringify.split("::").last.underscore + "_id" %}
-    def {{method_name}}
-      {{class_name.id}}.find_by({{foreign_key.id}}: self.id)
+    {% primary_key = options[:primary_key] || "id" %}
+
+    def {{method_name}} : {{class_name}}?
+      {{class_name.id}}.find_by({{foreign_key.id}}: self.{{primary_key.id}})
     end
 
-    def {{method_name}}=(children)
-      children.{{foreign_key.id}} = self.id
+    def {{method_name}}! : {{class_name}}
+      {{class_name.id}}.find_by!({{foreign_key.id}}: self.{{primary_key.id}})
+    end
+
+    def {{method_name}}=(child)
+      child.{{foreign_key.id}} = self.{{primary_key.id}}
     end
   end
 

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -120,6 +120,10 @@ module Granite::Fields
       {% end %}
     end
 
+    disable_granite_docs? def primary_key_value : {{PRIMARY[:type].id}} | Nil
+      {{PRIMARY[:name].id}}
+    end
+
     disable_granite_docs? def set_attributes(args : Hash(String | Symbol, Type))
       args.each do |k, v|
         cast_to_field(k, v.as(Type))

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -94,9 +94,9 @@ module Granite::Transactions
         params << value
       end
       begin
-        {% if primary_type.id == "Int32" %}
+        {% if primary_type.id == "Int32" && primary_auto == true %}
           @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: "{{primary_name}}").to_i32
-        {% elsif primary_type.id == "Int64" %}
+        {% elsif primary_type.id == "Int64" && primary_auto == true %}
           @{{primary_name}} = @@adapter.insert(@@table_name, fields, params, lastval: "{{primary_name}}")
         {% elsif primary_auto == true %}
           {% raise "Failed to define #{@type.name}#save: Primary key must be Int(32|64), or set `auto: false` for natural keys.\n\n  primary #{primary_name} : #{primary_type}, auto: false\n" %}


### PR DESCRIPTION
* Allows custom primary keys on `belongs_to` and `has_one` associations. 
* Adds bang, raise on nil, methods to `belongs_to` and `has_one` associations. 
* Makes the `has_many` association use whatever primary key is defined on the model, vs always assuming `id`