### PR TITLE
Add timezone support

### DIFF
--- a/spec/granite/fields/casting_spec.cr
+++ b/spec/granite/fields/casting_spec.cr
@@ -1,7 +1,16 @@
+require "../../spec_helper"
+
 describe "#casting_to_fields" do
   it "casts string to int" do
     model = Review.new({"downvotes" => "32"})
     model.downvotes.should eq 32
+  end
+
+  it "casts time with timezone" do
+    Granite.settings.default_timezone = "Asia/Shanghai"
+    created_at = Time.parse("2018-12-12 00:00:00 +00:00", "%F %T %:z", Time::Location::UTC)
+    model = Review.new({"created_at" => created_at})
+    model.created_at.should eq Time.parse("2018-12-12 08:00:00+0800", Granite::DATETIME_FORMAT, Granite.settings.default_timezone)
   end
 
   it "generates an error if casting fails" do

--- a/spec/granite/fields/timestamps_spec.cr
+++ b/spec/granite/fields/timestamps_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 # Can run this spec for sqlite after https://www.sqlite.org/draft/releaselog/3_24_0.html is released.
 {% if ["pg", "mysql"].includes? env("CURRENT_ADAPTER") %}
   describe "timestamps" do
-    it "consistently uses UTC for created_at" do
+    it "should uses UTC for created_at by default" do
       parent = Parent.new(name: "parent").tap(&.save)
       found_parent = Parent.find!(parent.id)
 
@@ -14,7 +14,7 @@ require "../../spec_helper"
       read_timestamp.location.should eq Time::Location::UTC
     end
 
-    it "consistently uses UTC for updated_at" do
+    it "should uses UTC for updated_at by default" do
       parent = Parent.new(name: "parent").tap(&.save)
       found_parent = Parent.find!(parent.id)
 
@@ -23,6 +23,32 @@ require "../../spec_helper"
 
       original_timestamp.location.should eq Time::Location::UTC
       read_timestamp.location.should eq Time::Location::UTC
+    end
+
+    it "should uses timezone for created_at" do
+      Granite.settings.default_timezone = "Asia/Shanghai"
+
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find!(parent.id)
+
+      original_timestamp = parent.created_at!
+      read_timestamp = found_parent.created_at!
+
+      original_timestamp.location.should eq Time::Location.load("Asia/Shanghai")
+      read_timestamp.location.should eq Time::Location.load("Asia/Shanghai")
+    end
+
+    it "should uses timezone for updated_at" do
+      Granite.settings.default_timezone = "Asia/Shanghai"
+
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find!(parent.id)
+
+      original_timestamp = parent.updated_at!
+      read_timestamp = found_parent.updated_at!
+
+      original_timestamp.location.should eq Time::Location.load("Asia/Shanghai")
+      read_timestamp.location.should eq Time::Location.load("Asia/Shanghai")
     end
 
     it "truncates the subsecond parts of created_at" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,6 +6,10 @@ Granite::Adapters << Granite::Adapter::Mysql.new({name: "mysql", url: ENV["MYSQL
 Granite::Adapters << Granite::Adapter::Pg.new({name: "pg", url: ENV["PG_DATABASE_URL"]})
 Granite::Adapters << Granite::Adapter::Sqlite.new({name: "sqlite", url: ENV["SQLITE_DATABASE_URL"]})
 
+Spec.before_each do
+  Granite.settings.default_timezone = Granite::TIME_ZONE
+end
+
 require "spec"
 require "../src/granite"
 require "../src/adapter/**"

--- a/src/granite.cr
+++ b/src/granite.cr
@@ -2,6 +2,7 @@ require "yaml"
 require "db"
 
 module Granite
+  TIME_ZONE       = "UTC"
   DATETIME_FORMAT = "%F %X%z"
 end
 

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -97,7 +97,7 @@ module Granite::Fields
       {% for name, options in FIELDS %}
         {% type = options[:type] %}
         {% if type.id == Time.id %}
-          fields["{{name}}"] = {{name.id}}.try(&.to_s(Granite::DATETIME_FORMAT))
+          fields["{{name}}"] = {{name.id}}.try(&.in(Granite.settings.default_timezone).to_s(Granite::DATETIME_FORMAT))
         {% elsif type.id == Slice.id %}
           fields["{{name}}"] = {{name.id}}.try(&.to_s(""))
         {% else %}
@@ -161,9 +161,9 @@ module Granite::Fields
               @{{_name.id}} = ["1", "yes", "true", true].includes?(value)
             {% elsif type.id == Time.id %}
               if value.is_a?(Time)
-                @{{_name.id}} = value
+                @{{_name.id}} = value.in(Granite.settings.default_timezone)
               elsif value.to_s =~ TIME_FORMAT_REGEX
-                @{{_name.id}} = Time.parse_utc(value.to_s, Granite::DATETIME_FORMAT)
+                @{{_name.id}} = Time.parse(value.to_s, Granite::DATETIME_FORMAT, Granite.settings.default_timezone)
               end
             {% else %}
               @{{_name.id}} = value.to_s

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -19,6 +19,9 @@ module Granite::Querying
         @new_record = false
         \{% for name, options in FIELDS %}
           self.\{{name.id}} = result.read(Union(\{{options[:type].id}} | Nil))
+          \{% if options[:type].id == "Time".id %}
+            self.\{{name.id}} = self.\{{name.id}}.not_nil!.in(Granite.settings.default_timezone) if self.\{{name.id}}
+          \{% end %}
         \{% end %}
         self
       end

--- a/src/granite/settings.cr
+++ b/src/granite/settings.cr
@@ -3,10 +3,17 @@ require "logger"
 module Granite
   class Settings
     property logger : Logger
+    property default_timezone : Time::Location
 
     def initialize
       @logger = Logger.new nil
       @logger.progname = "Granite"
+
+      @default_timezone = Time::Location.load(Granite::TIME_ZONE)
+    end
+
+    def default_timezone=(name : String)
+      @default_timezone = Time::Location.load(name)
     end
   end
 

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -73,15 +73,15 @@ module Granite::Transactions
       end
     end
 
-    disable_granite_docs? def set_timestamps(*, to time = Time.now, mode = :create)
+    disable_granite_docs? def set_timestamps(*, to time = Time.now(Granite.settings.default_timezone), mode = :create)
       {% if FIELDS.keys.stringify.includes? "created_at" %}
         if mode == :create
-          @created_at = time.to_utc.at_beginning_of_second
+          @created_at = time.at_beginning_of_second
         end
       {% end %}
 
       {% if FIELDS.keys.stringify.includes? "updated_at" %}
-        @updated_at = time.to_utc.at_beginning_of_second
+        @updated_at = time.at_beginning_of_second
       {% end %}
     end
 


### PR DESCRIPTION
Add timezone support to set and get value with `Time` type, but the row in database is still UTC, because [sqlite](https://github.com/crystal-lang/crystal-sqlite3/blob/master/src/sqlite3.cr#L8) and [mysql](https://github.com/crystal-lang/crystal-mysql/blob/master/src/mysql.cr#L16) shards defined a constant  `TIME_ZONE` use `Time::Location::UTC`

Add `default_timezone` property to `Granite::Settings`. setter accepts two types of value: `Time::Location` and `String` but getter returns a `Time::Location` type.

Example:

```crystal
Grante.settings.default_timezone = Time::Location.local
# Or
Grante.settings.default_timezone = "Asia/Shanghai"
```