### PR TITLE
Add colors to logged queries

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -1,7 +1,6 @@
 require "../granite"
 require "db"
 require "colorize"
-require "benchmark"
 
 # The Base Adapter specifies the interface that will be used by the model
 # objects to perform actions against a specific database.  Each adapter needs

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -104,11 +104,13 @@ abstract class Granite::Adapter::Base
   end
 
   private def colorize(query : String, params, elapsed_time : Benchmark::BM::Tms) : String
-    q = query.to_s.split(/([a-zA-Z0-9_$]+)/).map do |word|
+    q = query.to_s.split(/([a-zA-Z0-9_$']+)/).map do |word|
       if SQL_KEYWORDS.includes?(word.upcase)
         word.colorize.bold.blue.to_s
       elsif !word.starts_with?('$') && word =~ /\d+/
-        word.colorize.red
+        word.colorize.light_red
+      elsif word.starts_with?('\'') && word.ends_with?('\'')
+        word.colorize(Colorize::Color256.new(193))
       else
         word.colorize.white
       end

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -19,13 +19,13 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   def clear(table_name : String)
     statement = "TRUNCATE #{quote(table_name)}"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement
       end
     end
 
-    log statement, elapsed_time
+    log statement, elapsed_time unless Granite.settings.logger.nil?
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -38,7 +38,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     end
 
     last_id = -1_i64
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.using_connection do |conn|
           conn.exec statement, params
@@ -47,7 +47,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
 
     last_id
   end
@@ -83,13 +83,13 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   private def last_val : String
@@ -104,25 +104,25 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       stmt << " WHERE #{quote(primary_name)}=?"
     end
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   # This will delete a row from the database.
   def delete(table_name : String, primary_name : String, value)
     statement = "DELETE FROM #{quote(table_name)} WHERE #{quote(primary_name)}=?"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, value
       end
     end
 
-    log statement, elapsed_time, value
+    log statement, elapsed_time, value unless Granite.settings.logger.nil?
   end
 end

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -16,17 +16,19 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   end
 
   # Using TRUNCATE instead of DELETE so the id column resets to 0
-  def clear(table_name)
+  def clear(table_name : String)
     statement = "TRUNCATE #{quote(table_name)}"
 
-    log statement
-
-    open do |db|
-      db.exec statement
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement
+      end
     end
+
+    log statement, elapsed_time
   end
 
-  def insert(table_name, fields, params, lastval)
+  def insert(table_name : String, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")
@@ -35,18 +37,19 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       stmt << ")"
     end
 
-    log statement, params
-
-    open do |db|
-      db.using_connection do |conn|
-        conn.exec statement, params
-        if lastval
-          return conn.scalar(last_val()).as(Int64)
-        else
-          return -1_i64
+    last_id = -1_i64
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.using_connection do |conn|
+          conn.exec statement, params
+          last_id = conn.scalar(last_val()).as(Int64) if lastval
         end
       end
     end
+
+    log statement, elapsed_time, params
+
+    last_id
   end
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
@@ -80,40 +83,46 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, params
-
-    open do |db|
-      db.exec statement, params
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, params
+      end
     end
+
+    log statement, elapsed_time, params
   end
 
-  private def last_val
-    return "SELECT LAST_INSERT_ID()"
+  private def last_val : String
+    "SELECT LAST_INSERT_ID()"
   end
 
   # This will update a row in the database.
-  def update(table_name, primary_name, fields, params)
+  def update(table_name : String, primary_name : String, fields, params)
     statement = String.build do |stmt|
       stmt << "UPDATE #{quote(table_name)} SET "
       stmt << fields.map { |name| "#{quote(name)}=?" }.join(", ")
       stmt << " WHERE #{quote(primary_name)}=?"
     end
 
-    log statement, params
-
-    open do |db|
-      db.exec statement, params
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, params
+      end
     end
+
+    log statement, elapsed_time, params
   end
 
   # This will delete a row from the database.
-  def delete(table_name, primary_name, value)
+  def delete(table_name : String, primary_name : String, value)
     statement = "DELETE FROM #{quote(table_name)} WHERE #{quote(primary_name)}=?"
 
-    log statement, value
-
-    open do |db|
-      db.exec statement, value
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, value
+      end
     end
+
+    log statement, elapsed_time, value
   end
 end

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -26,13 +26,13 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   def clear(table_name : String)
     statement = "DELETE FROM #{quote(table_name)}"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement
       end
     end
 
-    log statement, elapsed_time
+    log statement, elapsed_time unless Granite.settings.logger.nil?
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -47,7 +47,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
 
     last_id = -1_i64
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         if lastval
           last_id = db.scalar(statement, params).as(Int32 | Int64).to_i64
@@ -57,7 +57,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
 
     last_id
   end
@@ -99,13 +99,13 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       statement += " ON CONFLICT DO NOTHING"
     end
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   # This will update a row in the database.
@@ -116,26 +116,26 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << " WHERE #{quote(primary_name)}=$#{fields.size + 1}"
     end
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   # This will delete a row from the database.
   def delete(table_name : String, primary_name : String, value)
     statement = "DELETE FROM #{quote(table_name)} WHERE #{quote(primary_name)}=$1"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, value
       end
     end
 
-    log statement, elapsed_time, value
+    log statement, elapsed_time, value unless Granite.settings.logger.nil?
   end
 
   def ensure_clause_template(clause : String) : String

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -18,17 +18,19 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   end
 
   # remove all rows from a table and reset the counter on the id.
-  def clear(table_name)
+  def clear(table_name : String)
     statement = "DELETE FROM #{quote(table_name)}"
 
-    log statement
-
-    open do |db|
-      db.exec statement
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement
+      end
     end
+
+    log statement, elapsed_time
   end
 
-  def insert(table_name, fields, params, lastval)
+  def insert(table_name : String, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")
@@ -37,16 +39,17 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       stmt << ")"
     end
 
-    log statement, params
-
-    open do |db|
-      db.exec statement, params
-      if lastval
-        return db.scalar(last_val()).as(Int64)
-      else
-        return -1_i64
+    last_id = -1_i64
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, params
+        last_id = db.scalar(last_val()).as(Int64) if lastval
       end
     end
+
+    log statement, elapsed_time, params
+
+    last_id
   end
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
@@ -73,11 +76,13 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end.chomp(',')
 
-    log statement, params
-
-    open do |db|
-      db.exec statement, params
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, params
+      end
     end
+
+    log statement, elapsed_time, params
   end
 
   private def last_val
@@ -85,28 +90,32 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   end
 
   # This will update a row in the database.
-  def update(table_name, primary_name, fields, params)
+  def update(table_name : String, primary_name : String, fields, params)
     statement = String.build do |stmt|
       stmt << "UPDATE #{quote(table_name)} SET "
       stmt << fields.map { |name| "#{quote(name)}=?" }.join(", ")
       stmt << " WHERE #{quote(primary_name)}=?"
     end
 
-    log statement, params
-
-    open do |db|
-      db.exec statement, params
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, params
+      end
     end
+
+    log statement, elapsed_time, params
   end
 
   # This will delete a row from the database.
-  def delete(table_name, primary_name, value)
+  def delete(table_name : String, primary_name : String, value)
     statement = "DELETE FROM #{quote(table_name)} WHERE #{quote(primary_name)}=?"
 
-    log statement, value
-
-    open do |db|
-      db.exec statement, value
+    elapsed_time = Benchmark.measure do
+      open do |db|
+        db.exec statement, value
+      end
     end
+
+    log statement, elapsed_time, value
   end
 end

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -21,13 +21,13 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   def clear(table_name : String)
     statement = "DELETE FROM #{quote(table_name)}"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement
       end
     end
 
-    log statement, elapsed_time
+    log statement, elapsed_time unless Granite.settings.logger.nil?
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -40,14 +40,14 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
 
     last_id = -1_i64
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
         last_id = db.scalar(last_val()).as(Int64) if lastval
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
 
     last_id
   end
@@ -76,13 +76,13 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end.chomp(',')
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   private def last_val
@@ -97,25 +97,25 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       stmt << " WHERE #{quote(primary_name)}=?"
     end
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, params
       end
     end
 
-    log statement, elapsed_time, params
+    log statement, elapsed_time, params unless Granite.settings.logger.nil?
   end
 
   # This will delete a row from the database.
   def delete(table_name : String, primary_name : String, value)
     statement = "DELETE FROM #{quote(table_name)} WHERE #{quote(primary_name)}=?"
 
-    elapsed_time = Benchmark.measure do
+    elapsed_time = Time.measure do
       open do |db|
         db.exec statement, value
       end
     end
 
-    log statement, elapsed_time, value
+    log statement, elapsed_time, value unless Granite.settings.logger.nil?
   end
 end

--- a/src/granite/query/executors/base.cr
+++ b/src/granite/query/executors/base.cr
@@ -5,8 +5,8 @@ module Granite::Query::Executor
     end
 
     def log(*messages)
-      messages.each do |message|
-        Granite.settings.logger.info message
+      if logger = Granite.settings.logger
+        messages.each { |message| logger.info message }
       end
     end
   end

--- a/src/granite/settings.cr
+++ b/src/granite/settings.cr
@@ -2,15 +2,8 @@ require "logger"
 
 module Granite
   class Settings
-    property logger : Logger
-    property default_timezone : Time::Location
-
-    def initialize
-      @logger = Logger.new nil
-      @logger.progname = "Granite"
-
-      @default_timezone = Time::Location.load(Granite::TIME_ZONE)
-    end
+    property logger : Logger? = nil
+    property default_timezone : Time::Location = Time::Location.load(Granite::TIME_ZONE)
 
     def default_timezone=(name : String)
       @default_timezone = Time::Location.load(name)

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -160,7 +160,9 @@ module Granite::Transactions
         __after_save
       rescue ex : DB::Error | Granite::Callbacks::Abort
         if message = ex.message
-          Granite.settings.logger.error "Save Exception: #{message}"
+          if logger = Granite.settings.logger
+            logger.error "Save Exception: #{message}"
+          end
           errors << Granite::Error.new(:base, message)
         end
         return false
@@ -201,7 +203,9 @@ module Granite::Transactions
         __after_destroy
       rescue ex : DB::Error | Granite::Callbacks::Abort
         if message = ex.message
-          Granite.settings.logger.error "Destroy Exception: #{message}"
+          if logger = Granite.settings.logger
+            logger.error "Destroy Exception: #{message}"
+          end
           errors << Granite::Error.new(:base, message)
         end
         return false


### PR DESCRIPTION
Adds color and execution time to logged queries.

Totally steals the humanize duration from @robacarp's mosquito lib :wink: 

Can ignore everything up to the execution time, everything else is because im running in docker and mosquito.

SELECT:
![image](https://user-images.githubusercontent.com/12136995/50732447-ad57ad80-1149-11e9-92d8-73f67ceae59d.png)

INSERT:
![image](https://user-images.githubusercontent.com/12136995/50732463-ef80ef00-1149-11e9-825d-da0b67870c1b.png)

With Numbers:
![image](https://user-images.githubusercontent.com/12136995/50732470-0fb0ae00-114a-11e9-83f3-2e219b3a1ac3.png)
