### PR TITLE
Support default values

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -133,6 +133,21 @@ book.isbn # => nil
 book.save
 book.isbn # => RFC4122 V4 UUID string
 ```
+### Default values
+
+A default value can be assigned to a field that will be used if another value is not specified/supplies.
+
+```Crystal
+class Book < Granite::Base
+  adapter mysql
+  
+  field name : String, default: "DefaultBook"
+end
+
+book = Book.new
+book.name # => "DefaultBook"
+```
+
 
 ### Generating Documentation
 
@@ -141,8 +156,6 @@ By default, running `crystal docs` will **not** include Granite methods, constan
 The `field` and `primary` macros have a comment option that will specify the documentation comment to apply to that property's getter and setter.
 
 `field age : Int32, comment: "# Number of seconds since the post was posted"`
-
-See the [Docs folder](./) for additional information.
 
 ### Third-Party Annotations
 

--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -1,6 +1,13 @@
 require "./spec_helper"
 
-describe "Granite::Base" do
+describe Granite::Base do
+  it "can instaniate a model with default values" do
+    model = DefaultValues.new
+    model.name.should eq "Jim"
+    model.age.should eq 0.0
+    model.is_alive.should be_true
+  end
+
   describe "JSON" do
     describe ".from_json" do
       it "can create an object from json" do
@@ -39,6 +46,15 @@ describe "Granite::Base" do
 
         model.name.should eq "after_initialize"
         model.priority.should eq 1000
+      end
+
+      describe "with default values" do
+        it "correctly applies values" do
+          model = DefaultValues.from_json(%({"name": "Bob"}))
+          model.name.should eq "Bob"
+          model.age.should eq 0.0
+          model.is_alive.should be_true
+        end
       end
     end
 
@@ -135,6 +151,15 @@ describe "Granite::Base" do
 
         model.name.should eq "after_initialize"
         model.priority.should eq 1000
+      end
+
+      describe "with default values" do
+        it "correctly applies values" do
+          model = DefaultValues.from_yaml(%(---\nname: Bob))
+          model.name.should eq "Bob"
+          model.age.should eq 0.0
+          model.is_alive.should be_true
+        end
       end
     end
 
@@ -249,6 +274,8 @@ describe "Granite::Base" do
           model = ArrayModel.new
           model.id = 2
           model.str_array = [] of String
+          model.f64_array.should be_a(Array(Float64))
+          model.f64_array.should eq [] of Float64
           model.save.should be_true
         end
 
@@ -260,7 +287,8 @@ describe "Granite::Base" do
           model.i32_array.should be_nil
           model.i64_array.should be_nil
           model.f32_array.should be_nil
-          model.f64_array.should be_nil
+          model.f64_array.should be_a(Array(Float64))
+          model.f64_array.should eq [] of Float64
           model.bool_array.should be_nil
         end
       end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -340,9 +340,9 @@ require "uuid"
       field str_array : Array(String)
       field i16_array : Array(Int16)
       field i32_array : Array(Int32)
-      field i64_array : Array(Int64), default: [] of Float64
+      field i64_array : Array(Int64)
       field f32_array : Array(Float32)
-      field f64_array : Array(Float64)
+      field f64_array : Array(Float64), default: [] of Float64
       field bool_array : Array(Bool)
     end
     ArrayModel.migrator.drop_and_create

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -340,7 +340,7 @@ require "uuid"
       field str_array : Array(String)
       field i16_array : Array(Int16)
       field i32_array : Array(Int32)
-      field i64_array : Array(Int64)
+      field i64_array : Array(Int64), default [] of Float64
       field f32_array : Array(Float32)
       field f64_array : Array(Float64)
       field bool_array : Array(Bool)
@@ -373,6 +373,15 @@ require "uuid"
     field priority : Int32, yaml_options: {ignore: true}
     field updated_at : Time, yaml_options: {ignore: true}
     field created_at : Time, yaml_options: {key: "posted"}
+  end
+
+  class DefaultValues < Granite::Base
+    adapter {{ adapter_literal }}
+    table_name defaults
+
+    field name : String, default: "Jim"
+    field is_alive : Bool, default: true
+    field age : Float64, default: 0.0
   end
 
   module Validators
@@ -493,49 +502,50 @@ require "uuid"
       validate_exclusion :name, ["test_name"]
     end
 
-    NilTest.migrator.drop_and_create
     BlankTest.migrator.drop_and_create
     ChoiceTest.migrator.drop_and_create
-    LessThanTest.migrator.drop_and_create
+    ExclusionTest.migrator.drop_and_create
     GreaterThanTest.migrator.drop_and_create
     LengthTest.migrator.drop_and_create
+    LessThanTest.migrator.drop_and_create
+    NilTest.migrator.drop_and_create
     PersonUniqueness.migrator.drop_and_create
-    ExclusionTest.migrator.drop_and_create
   end
 
-  Parent.migrator.drop_and_create
-  Teacher.migrator.drop_and_create
-  Student.migrator.drop_and_create
-  Klass.migrator.drop_and_create
-  Enrollment.migrator.drop_and_create
-  School.migrator.drop_and_create
-  User.migrator.drop_and_create
-  Profile.migrator.drop_and_create
-  Nation::County.migrator.drop_and_create
-  Review.migrator.drop_and_create
-  Empty.migrator.drop_and_create
-  ReservedWord.migrator.drop_and_create
-  Callback.migrator.drop_and_create
-  CallbackWithAbort.migrator.drop_and_create
-  Kvs.migrator.drop_and_create
-  Person.migrator.drop_and_create
-  Company.migrator.drop_and_create
+  AfterInit.migrator.drop_and_create
+  Article.migrator.drop_and_create
   Book.migrator.drop_and_create
   BookReview.migrator.drop_and_create
-  Item.migrator.drop_and_create
-  NonAutoDefaultPK.migrator.drop_and_create
-  NonAutoCustomPK.migrator.drop_and_create
-  Article.migrator.drop_and_create
-  Comment.migrator.drop_and_create
-  Todo.migrator.drop_and_create
-  TodoEmitNull.migrator.drop_and_create
-  AfterInit.migrator.drop_and_create
-  SongThread.migrator.drop_and_create
-  CustomSongThread.migrator.drop_and_create
-  UUIDModel.migrator.drop_and_create
-  TodoJsonOptions.migrator.drop_and_create
-  TodoYamlOptions.migrator.drop_and_create
+  Callback.migrator.drop_and_create
+  CallbackWithAbort.migrator.drop_and_create
   Character.migrator.drop_and_create
+  Comment.migrator.drop_and_create
+  Company.migrator.drop_and_create
   Courier.migrator.drop_and_create
   CourierService.migrator.drop_and_create
+  CustomSongThread.migrator.drop_and_create
+  DefaultValues.migrator.drop_and_create
+  Empty.migrator.drop_and_create
+  Enrollment.migrator.drop_and_create
+  Item.migrator.drop_and_create
+  Klass.migrator.drop_and_create
+  Kvs.migrator.drop_and_create
+  Nation::County.migrator.drop_and_create
+  NonAutoCustomPK.migrator.drop_and_create
+  NonAutoDefaultPK.migrator.drop_and_create
+  Parent.migrator.drop_and_create
+  Person.migrator.drop_and_create
+  Profile.migrator.drop_and_create
+  ReservedWord.migrator.drop_and_create
+  Review.migrator.drop_and_create
+  School.migrator.drop_and_create
+  SongThread.migrator.drop_and_create
+  Student.migrator.drop_and_create
+  Teacher.migrator.drop_and_create
+  Todo.migrator.drop_and_create
+  TodoEmitNull.migrator.drop_and_create
+  TodoJsonOptions.migrator.drop_and_create
+  TodoYamlOptions.migrator.drop_and_create
+  User.migrator.drop_and_create
+  UUIDModel.migrator.drop_and_create
 {% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -340,7 +340,7 @@ require "uuid"
       field str_array : Array(String)
       field i16_array : Array(Int16)
       field i32_array : Array(Int32)
-      field i64_array : Array(Int64), default [] of Float64
+      field i64_array : Array(Int64), default: [] of Float64
       field f32_array : Array(Float32)
       field f64_array : Array(Float64)
       field bool_array : Array(Bool)

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -82,12 +82,15 @@ abstract class Granite::Adapter::Base
   macro inherited
     # quotes table and column names
     def quote(name : String) : String
-      char = QUOTING_CHAR
-      char + name.gsub(char, "#{char}#{char}") + char
+      String.build do |str|
+        str << QUOTING_CHAR
+        str << name
+        str << QUOTING_CHAR
+      end
     end
 
     # converts the crystal class to database type of this adapter
-    def self.schema_type?(key : String)
+    def self.schema_type?(key : String) : String?
       Schema::TYPES[key]? || Granite::Adapter::Base::Schema::TYPES[key]?
     end
   end

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -66,7 +66,7 @@ module Granite::Fields
       {% if options[:comment] %}
          {{options[:comment].id}}
       {% end %}
-      property{{suffixes[0].id}} {{name.id}} : Union({{type.id}} | Nil)
+      property{{suffixes[0].id}} {{name.id}} : Union({{type.id}} | Nil){% if options[:default] %} = {{options[:default]}} {% end %}
       disable_granite_docs? def {{name.id}}{{suffixes[1].id}}
         raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
         @{{name.id}}.not_nil!


### PR DESCRIPTION
Adds the ability to define default values.  Changes `#quote` to use `String.build` vs `#gsub` and `+`.  

```
         quote   9.23M (108.35ns) (± 3.16%)  256 B/op   1.60× slower
string builder   14.8M ( 67.58ns) (± 1.12%)  208 B/op        fastest
```