### PR TITLE
Support array IN queries with query builder

### DIFF
--- a/spec/granite/fields/field_spec.cr
+++ b/spec/granite/fields/field_spec.cr
@@ -1,6 +1,6 @@
 require "../../spec_helper"
 
-{% if env("CURRENT_ENV") == "pg" %}
+{% if env("CURRENT_ADAPTER") == "pg" %}
   class Field < Granite::Base
     adapter pg
 

--- a/spec/granite/query/assemblers/mysql_spec.cr
+++ b/spec/granite/query/assemblers/mysql_spec.cr
@@ -33,6 +33,26 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Fields::Type
       end
+
+      it "property defines IN query with numbers" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND id IN (1,2) ORDER BY id DESC"
+        query = builder.where(date_completed: nil, id: [1, 2])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
+
+      it "property defines IN query with booleans" do
+        sql = "SELECT #{query_fields} FROM table WHERE published IN (true,false) ORDER BY id DESC"
+        query = builder.where(published: [true, false])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/mysql_spec.cr
+++ b/spec/granite/query/assemblers/mysql_spec.cr
@@ -23,6 +23,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq ["bob", "23"]
       end
+
+      it "property defines IN query" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND status IN ('outstanding','in_progress') ORDER BY id DESC"
+        query = builder.where(date_completed: nil, status: ["outstanding", "in_progress"])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/pg_spec.cr
+++ b/spec/granite/query/assemblers/pg_spec.cr
@@ -33,6 +33,26 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Fields::Type
       end
+
+      it "property defines IN query with numbers" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND id IN (1,2) ORDER BY id DESC"
+        query = builder.where(date_completed: nil, id: [1, 2])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
+
+      it "property defines IN query with booleans" do
+        sql = "SELECT #{query_fields} FROM table WHERE published IN (true,false) ORDER BY id DESC"
+        query = builder.where(published: [true, false])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/pg_spec.cr
+++ b/spec/granite/query/assemblers/pg_spec.cr
@@ -23,6 +23,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq ["bob", "23"]
       end
+
+      it "property defines IN query" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND status IN ('outstanding','in_progress') ORDER BY id DESC"
+        query = builder.where(date_completed: nil, status: ["outstanding", "in_progress"])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/sqlite_spec.cr
+++ b/spec/granite/query/assemblers/sqlite_spec.cr
@@ -33,6 +33,26 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Fields::Type
       end
+
+      it "property defines IN query with numbers" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND id IN (1,2) ORDER BY id DESC"
+        query = builder.where(date_completed: nil, id: [1, 2])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
+
+      it "property defines IN query with booleans" do
+        sql = "SELECT #{query_fields} FROM table WHERE published IN (true,false) ORDER BY id DESC"
+        query = builder.where(published: [true, false])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/sqlite_spec.cr
+++ b/spec/granite/query/assemblers/sqlite_spec.cr
@@ -23,6 +23,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq ["bob", "23"]
       end
+
+      it "property defines IN query" do
+        sql = "SELECT #{query_fields} FROM table WHERE date_completed IS NULL AND status IN ('outstanding','in_progress') ORDER BY id DESC"
+        query = builder.where(date_completed: nil, status: ["outstanding", "in_progress"])
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq [] of Granite::Fields::Type
+      end
     end
 
     context "order" do

--- a/spec/granite/query/builder_spec.cr
+++ b/spec/granite/query/builder_spec.cr
@@ -28,6 +28,16 @@ describe Granite::Query::Builder(Model) do
     query.order_fields.should eq expected
   end
 
+  it "maps array to :in" do
+    query = builder.where(date_completed: nil, status: ["outstanding", "in_progress"])
+    expected = [
+      {join: :and, field: "date_completed", operator: :eq, value: nil},
+      {join: :and, field: "status", operator: :in, value: ["outstanding", "in_progress"]},
+    ]
+
+    query.where_fields.should eq expected
+  end
+
   it "stores limit" do
     query = builder.limit(7)
     query.limit.should eq 7

--- a/spec/granite/querying/query_builder_spec.cr
+++ b/spec/granite/querying/query_builder_spec.cr
@@ -1,0 +1,50 @@
+require "../../spec_helper"
+
+describe "#query_builder_methods" do
+  describe "#where" do
+    describe "with array argument" do
+      it "correctly queries string fields" do
+        review1 = Review.create(name: "one")
+        review2 = Review.create(name: "two")
+
+        found = Review.where(name: ["one", "two"]).select
+        found[0].id.should eq review2.id
+        found[1].id.should eq review1.id
+      end
+
+      it "correctly queries number fields" do
+        Review.clear
+        review1 = Review.create(name: "one", downvotes: 99)
+        review2 = Review.create(name: "two", downvotes: -4)
+
+        found = Review.where(downvotes: [99, -4]).select
+        found[0].id.should eq review2.id
+        found[1].id.should eq review1.id
+      end
+
+      # Sqlite doesnt have bool literals
+      {% if env("CURRENT_ADAPTER") == "sqlite" %}
+        it "correctly queries bool fields" do
+          Review.clear
+          Review.create(name: "one", published: 1)
+          review2 = Review.create(name: "two", published: 0)
+
+          found = Review.where(published: [0]).select
+
+          found.size.should eq 1
+          found[0].id.should eq review2.id
+        end
+      {% else %}
+        it "correctly queries bool fields" do
+          Review.clear
+          Review.create(name: "one", published: true)
+          review2 = Review.create(name: "two", published: false)
+
+          found = Review.where(published: [false]).select
+          found.size.should eq 1
+          found[0].id.should eq review2.id
+        end
+      {% end %}
+    end
+  end
+end

--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -209,7 +209,7 @@ describe "Granite::Base" do
   end
 
   # Only PG supports array types
-  {% if env("CURRENT_ENV") == "pg" %}
+  {% if env("CURRENT_ADAPTER") == "pg" %}
     describe "Array(T)" do
       describe "with values" do
         it "should save correctly" do

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -332,7 +332,7 @@ require "uuid"
   end
 
   # Only PG supports array types
-  {% if env("CURRENT_ENV") == "pg" %}
+  {% if env("CURRENT_ADAPTER") == "pg" %}
     class ArrayModel < Granite::Base
       adapter {{ adapter_literal }}
 

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -50,7 +50,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   end
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
-    params = [] of DB::Any
+    params = [] of Granite::Fields::Type
 
     statement = String.build do |stmt|
       stmt << "INSERT"

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -57,7 +57,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   end
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
-    params = [] of DB::Any
+    params = [] of Granite::Fields::Type
     # PG fails when inserting null into AUTO INCREMENT PK field.
     # If AUTO INCREMENT is TRUE AND all model's pk are nil, remove PK from fields list for AUTO INCREMENT to work properly
     fields.reject! { |field| field == primary_name } if model_array.all? { |m| m.to_h[primary_name].nil? } && auto == "true"

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -50,7 +50,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   end
 
   def import(table_name : String, primary_name : String, auto : String, fields, model_array, **options)
-    params = [] of DB::Any
+    params = [] of Granite::Fields::Type
 
     statement = String.build do |stmt|
       stmt << "INSERT "

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -158,7 +158,7 @@ module Granite::Fields
             {% elsif type.id == Float64.id %}
               @{{_name.id}} = value.is_a?(String) ? value.to_f64(strict: false) : value.as(Float64)
             {% elsif type.id == Bool.id %}
-              @{{_name.id}} = ["1", "yes", "true", true].includes?(value)
+              @{{_name.id}} = ["1", "yes", "true", true, 1].includes?(value)
             {% elsif type.id == Time.id %}
               if value.is_a?(Time)
                 @{{_name.id}} = value.in(Granite.settings.default_timezone)

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -51,9 +51,9 @@ module Granite::Query::Assembler
           in_stmt = String.build do |str|
             str << '('
             expression[:value].as(Array).each_with_index do |val, idx|
-              str << '\''
+              str << '\'' if expression[:value].is_a?(Array(String))
               str << val
-              str << '\''
+              str << '\'' if expression[:value].is_a?(Array(String))
               str << ',' if expression[:value].as(Array).size - 1 != idx
             end
             str << ')'

--- a/src/granite/query/assemblers/mysql.cr
+++ b/src/granite/query/assemblers/mysql.cr
@@ -2,7 +2,7 @@
 # This will likely require adapter specific subclassing :[.
 module Granite::Query::Assembler
   class Mysql(Model) < Base(Model)
-    def add_parameter(value : DB::Any) : String
+    def add_parameter(value : Granite::Fields::Type) : String
       @numbered_parameters << value
       "?"
     end

--- a/src/granite/query/assemblers/pg.cr
+++ b/src/granite/query/assemblers/pg.cr
@@ -2,7 +2,7 @@
 # This will likely require adapter specific subclassing :[.
 module Granite::Query::Assembler
   class Pg(Model) < Base(Model)
-    def add_parameter(value : DB::Any) : String
+    def add_parameter(value : Granite::Fields::Type) : String
       @numbered_parameters << value
       "$#{@numbered_parameters.size}"
     end

--- a/src/granite/query/assemblers/sqlite.cr
+++ b/src/granite/query/assemblers/sqlite.cr
@@ -1,6 +1,6 @@
 module Granite::Query::Assembler
   class Sqlite(Model) < Base(Model)
-    def add_parameter(value : DB::Any) : String
+    def add_parameter(value : Granite::Fields::Type) : String
       @numbered_parameters << value
       "?"
     end

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -28,7 +28,7 @@ class Granite::Query::Builder(Model)
   end
 
   getter db_type : DbType
-  getter where_fields = [] of NamedTuple(join: Symbol, field: String, operator: Symbol, value: DB::Any)
+  getter where_fields = [] of NamedTuple(join: Symbol, field: String, operator: Symbol, value: Granite::Fields::Type)
   getter order_fields = [] of NamedTuple(field: String, direction: Sort)
   getter offset : Int64?
   getter limit : Int64?
@@ -55,13 +55,17 @@ class Granite::Query::Builder(Model)
 
   def where(matches)
     matches.each do |field, value|
-      and(field: field.to_s, operator: :eq, value: value)
+      if value.is_a?(Array)
+        and(field: field.to_s, operator: :in, value: value)
+      else
+        and(field: field.to_s, operator: :eq, value: value)
+      end
     end
 
     self
   end
 
-  def where(field : (Symbol | String), operator : Symbol, value : DB::Any)
+  def where(field : (Symbol | String), operator : Symbol, value : Granite::Fields::Type)
     and(field: field.to_s, operator: operator, value: value)
   end
 
@@ -77,7 +81,7 @@ class Granite::Query::Builder(Model)
     self
   end
 
-  def and(field : (Symbol | String), operator : Symbol, value : DB::Any)
+  def and(field : (Symbol | String), operator : Symbol, value : Granite::Fields::Type)
     @where_fields << {join: :and, field: field.to_s, operator: operator, value: value}
 
     self
@@ -95,7 +99,7 @@ class Granite::Query::Builder(Model)
     self
   end
 
-  def or(field : (Symbol | String), operator : Symbol, value : DB::Any)
+  def or(field : (Symbol | String), operator : Symbol, value : Granite::Fields::Type)
     @where_fields << {join: :or, field: field.to_s, operator: operator, value: value}
 
     self

--- a/src/granite/query/executors/list.cr
+++ b/src/granite/query/executors/list.cr
@@ -2,7 +2,7 @@ module Granite::Query::Executor
   class List(Model)
     include Shared
 
-    def initialize(@sql : String, @args = [] of DB::Any)
+    def initialize(@sql : String, @args = [] of Granite::Fields::Type)
     end
 
     def run : Array(Model)

--- a/src/granite/query/executors/value.cr
+++ b/src/granite/query/executors/value.cr
@@ -2,7 +2,7 @@ module Granite::Query::Executor
   class Value(Model, Scalar)
     include Shared
 
-    def initialize(@sql : String, @args = [] of DB::Any, @default : Scalar = nil)
+    def initialize(@sql : String, @args = [] of Granite::Fields::Type, @default : Scalar = nil)
     end
 
     def run : Scalar


### PR DESCRIPTION
Allows for the query builder to handle params that are arrays.  It auto casts them to an `:in` query.

```
Courier.where(date_completed: nil, status: ["outstanding", "in_progress"]).select

SELECT contract_id, status, date_completed FROM couriers WHERE date_completed IS NULL AND status IN ('outstanding','in_progress') ORDER BY contract_id DESC
```

I had some trouble using placeholder vars in this context.  Both `["('outstanding','in_progress')"]` and `[["outstanding", "in_progress"]]` caused a syntax error.  To get around this i just build out the IN statement and plop in the value into the query.  Any ideas on how to better handle this?