### PR TITLE
Logger optimization

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "logger"
 
 describe Granite::Base do
   it "can instaniate a model with default values" do
@@ -6,6 +7,30 @@ describe Granite::Base do
     model.name.should eq "Jim"
     model.age.should eq 0.0
     model.is_alive.should be_true
+  end
+
+  describe Logger do
+    describe "when logger is set to IO" do
+      it "should be logged as DEBUG" do
+        IO.pipe do |r, w|
+          Granite.settings.logger = Logger.new(w, Logger::Severity::DEBUG)
+
+          Person.first
+
+          r.gets.should match /D, \[.*\] DEBUG -- : .*SELECT.*people.*id.*FROM.*people.*LIMIT.*1.*: .*\[\]/
+        end
+      end
+    end
+
+    describe "when logger is set to nil" do
+      it "should not be logged" do
+        Granite.settings.logger = Logger.new nil
+
+        a = 0
+        Granite.settings.logger.info { a = 1 }
+        a.should eq 0
+      end
+    end
   end
 
   describe "JSON" do

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -31,7 +31,7 @@ abstract class Granite::Adapter::Base
   end
 
   def log(query : String, elapsed_time : Time::Span, params = [] of String) : Nil
-    (logger = Granite.settings.logger) ? logger.info colorize query, params, elapsed_time.total_seconds : nil
+    Granite.settings.logger.debug { colorize query, params, elapsed_time.total_seconds }
   end
 
   # remove all rows from a table and reset the counter on the id.
@@ -57,7 +57,7 @@ abstract class Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   def ensure_clause_template(clause)

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -25,7 +25,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time unless Granite.settings.logger.nil?
+    log statement, elapsed_time
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -47,7 +47,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
 
     last_id
   end
@@ -89,7 +89,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   private def last_val : String
@@ -110,7 +110,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   # This will delete a row from the database.
@@ -123,6 +123,6 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, value unless Granite.settings.logger.nil?
+    log statement, elapsed_time, value
   end
 end

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -32,7 +32,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time unless Granite.settings.logger.nil?
+    log statement, elapsed_time
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -57,7 +57,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
 
     last_id
   end
@@ -105,7 +105,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   # This will update a row in the database.
@@ -122,7 +122,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   # This will delete a row from the database.
@@ -135,7 +135,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, value unless Granite.settings.logger.nil?
+    log statement, elapsed_time, value
   end
 
   def ensure_clause_template(clause : String) : String

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -27,7 +27,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time unless Granite.settings.logger.nil?
+    log statement, elapsed_time
   end
 
   def insert(table_name : String, fields, params, lastval)
@@ -47,7 +47,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
 
     last_id
   end
@@ -82,7 +82,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   private def last_val
@@ -103,7 +103,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, params unless Granite.settings.logger.nil?
+    log statement, elapsed_time, params
   end
 
   # This will delete a row from the database.
@@ -116,6 +116,6 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
       end
     end
 
-    log statement, elapsed_time, value unless Granite.settings.logger.nil?
+    log statement, elapsed_time, value
   end
 end

--- a/src/granite/settings.cr
+++ b/src/granite/settings.cr
@@ -2,7 +2,7 @@ require "logger"
 
 module Granite
   class Settings
-    property logger : Logger? = nil
+    property logger : Logger = Logger.new nil
     property default_timezone : Time::Location = Time::Location.load(Granite::TIME_ZONE)
 
     def default_timezone=(name : String)

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -160,9 +160,7 @@ module Granite::Transactions
         __after_save
       rescue ex : DB::Error | Granite::Callbacks::Abort
         if message = ex.message
-          if logger = Granite.settings.logger
-            logger.error "Save Exception: #{message}"
-          end
+          Granite.settings.logger.error { "Save Exception: #{message}" }
           errors << Granite::Error.new(:base, message)
         end
         return false
@@ -203,9 +201,7 @@ module Granite::Transactions
         __after_destroy
       rescue ex : DB::Error | Granite::Callbacks::Abort
         if message = ex.message
-          if logger = Granite.settings.logger
-            logger.error "Destroy Exception: #{message}"
-          end
+          Granite.settings.logger.error { "Destroy Exception: #{message}" }
           errors << Granite::Error.new(:base, message)
         end
         return false


### PR DESCRIPTION
@Rx14 brought to my attention a better way to implement the feature where logging doesnt run if the logger's io is nil.

https://github.com/amberframework/granite/compare/master...Blacksmoke16:logger-optimization?expand=1#diff-094e647002b88e121bcba1392f8416a8R34

Since we are calling the `colorize` method inside the block of `Granite.settings.logger.debug`, it will return before executing `colorize` if the IO is set to nil.  Because of this, I was able to reset the logger's type to `Logger`, and revert the nil checks i was doing.  Also because of this https://github.com/amberframework/amber/pull/1027 can be reverted once this is released.