### PR TITLE
Make migrator.create behave similarly to migrator.drop

### DIFF
--- a/src/granite/migrator.cr
+++ b/src/granite/migrator.cr
@@ -53,7 +53,7 @@ module Granite::Migrator
         }
 
         stmt = String.build do |s|
-          s.puts "CREATE TABLE #{ @quoted_table_name }("
+          s.puts "CREATE TABLE IF NOT EXISTS #{ @quoted_table_name }("
 
           # primary key
           k = {{adapter}}.quote("{{primary_name}}")


### PR DESCRIPTION
Currently, migrator.drop will `DROP IF EXISTS` to avoid erroring when there's nothing to be dropped - similarly, create shouldn't error when there's nothing to create