### PR TITLE
Raise NilAssertionError on nil value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.27.2
 
 ARG sqlite_version=3110000
 ARG sqlite_version_year=2016

--- a/spec/granite/fields/field_spec.cr
+++ b/spec/granite/fields/field_spec.cr
@@ -17,7 +17,7 @@ require "../../spec_helper"
         field.normal.should eq(1)
         field.normal!.should eq(1)
         nil_field.normal.should be_nil
-        expect_raises(Exception, "Field#normal cannot be nil") { nil_field.normal! }
+        expect_raises(NilAssertionError, "Field#normal cannot be nil") { nil_field.normal! }
       end
     end
 
@@ -28,7 +28,7 @@ require "../../spec_helper"
 
         field.raise_on_nil.should eq(1)
         field.raise_on_nil?.should eq(1)
-        expect_raises(Exception, "Field#raise_on_nil cannot be nil") { nil_field.raise_on_nil }
+        expect_raises(NilAssertionError, "Field#raise_on_nil cannot be nil") { nil_field.raise_on_nil }
         nil_field.raise_on_nil?.should be_nil
       end
     end

--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -68,7 +68,7 @@ module Granite::Fields
       {% end %}
       property{{suffixes[0].id}} {{name.id}} : Union({{type.id}} | Nil){% if options[:default] %} = {{options[:default]}} {% end %}
       disable_granite_docs? def {{name.id}}{{suffixes[1].id}}
-        raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
+        raise NilAssertionError.new {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
         @{{name.id}}.not_nil!
       end
     {% end %}


### PR DESCRIPTION
Now that https://github.com/crystal-lang/crystal/pull/7330 is merged and released, we should probably raise a `NilAssertionError` to be consistent.