### PR TITLE
Do not update created_at on update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.27.2
 
 ARG sqlite_version=3110000
 ARG sqlite_version_year=2016

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -20,6 +20,27 @@ describe "#update" do
 
     Parent.find!(parent.id).name.should eq "New Parent"
   end
+
+  context "when created_at is nil" do
+    it "does not update created_at" do
+      parent = Parent.new(name: "New Parent")
+      parent.save!
+
+      created_at = parent.created_at!.at_beginning_of_second
+
+      # Simulating instantiating a new object with same ID
+      new_parent = Parent.new(name: "New New Parent")
+      new_parent.id = parent.id
+      new_parent.new_record = false
+      new_parent.updated_at = parent.updated_at
+      new_parent.save!
+
+      saved_parent = Parent.find!(parent.id)
+      saved_parent.name.should eq "New New Parent"
+      saved_parent.created_at.should eq created_at
+      saved_parent.updated_at.should eq Time.utc_now.at_beginning_of_second
+    end
+  end
 end
 
 describe "#update!" do

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -125,8 +125,14 @@ module Granite::Transactions
 
     private def __update
       set_timestamps mode: :update
-      fields = self.class.content_fields
+      fields = self.class.content_fields.dup
       params = content_values + [@{{primary_name}}]
+
+      # Do not update created_at on update
+      if created_at_index = fields.index("created_at")
+        fields.delete_at created_at_index
+        params.delete_at created_at_index
+      end
 
       begin
         @@adapter.update @@table_name, @@primary_name, fields, params
@@ -239,7 +245,7 @@ module Granite::Transactions
   # Returns true if this object hasn't been saved yet.
   @[JSON::Field(ignore: true)]
   @[YAML::Field(ignore: true)]
-  getter? new_record : Bool = true
+  property? new_record : Bool = true
 
   # Returns true if this object has been destroyed.
   @[JSON::Field(ignore: true)]


### PR DESCRIPTION
This PR makes it so that when updating a record (that has a valid ID and `new_record = false`), with a `nil` `created_at`, it should not update the `created_at` field in the DB.

I noticed this (and the PRs before this) while working on my blog/tutorial post.  Where I was working on updating an object from the JSON PUT body like:
```json
{
  "id": 12,
  "user_id": 7,
  "title": "My Blog",
  "body": "The Blog!",
  "updated_at": "2019-02-23T15:32:03Z"
}
```
However, since `created_at` was not included, it was getting set to `nil`, which upon saving the record, was overriding the `created_at` column to be null.  Which, even if it _was_ set, it should not be included in the `UPDATE` query.

I also changed the `new_record` getter to a property.  The use case for this is so that external shards could add extensions to instantiate an object from something, and tell granite that it should be treated as an existing model.  Whereas before it was only directly set when fetching directly from the database or saving it for the first time.