### PR TITLE
Make primary_type return the class type vs string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.27.2
 
 ARG sqlite_version=3110000
 ARG sqlite_version_year=2016

--- a/spec/granite/table/table_spec.cr
+++ b/spec/granite/table/table_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
 describe Granite::Table do
-  describe "#table_name" do
+  describe ".table_name" do
     it "sets the table name to name specified" do
       CustomSongThread.table_name.should eq "custom_table_name"
     end
@@ -11,12 +11,26 @@ describe Granite::Table do
     end
   end
 
-  describe "#primary" do
+  describe ".primary_name" do
     it "sets the primary key name to name specified" do
       CustomSongThread.primary_name.should eq "custom_primary_key"
     end
     it "sets the primary key name to id if not specified" do
       SongThread.primary_name.should eq "id"
+    end
+  end
+
+  describe ".primary_type" do
+    describe "for a custom primary key" do
+      it "returns the class of the primary key's type" do
+        Kvs.primary_type.should eq String
+      end
+    end
+
+    describe "for the default primary key" do
+      it "returns the class of the primary key's type for a defautl type" do
+        Person.primary_type.should eq Int64
+      end
     end
   end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -44,7 +44,7 @@ module Granite::Table
     @@table_name = "{{table_name}}"
     @@primary_name = "{{primary_name}}"
     @@primary_auto = "{{primary_auto}}"
-    @@primary_type = "{{primary_type}}"
+    @@primary_type = {{primary_type}}
 
     disable_granite_docs? def self.table_name
       @@table_name


### PR DESCRIPTION
Makes the `primary_type` method return the actual `.class` type of the primary key, versus a string.  Having the actual type is much more useful.