### PR TITLE
Some updates for Crystal 0.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.2
+FROM crystallang/crystal:0.28.0
 
 ARG sqlite_version=3110000
 ARG sqlite_version_year=2016

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 dru.jensen
+Copyright (c) 2019 dru.jensen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   spec:
     build: .
-    command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && crystal spec"'
+    command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && crystal spec --warnings all --error-on-warnings"'
     working_dir: /app/user
     environment:
       PG_DATABASE_URL: 'postgres://postgres:@pg:5432/postgres'

--- a/docs/json_support.md
+++ b/docs/json_support.md
@@ -76,7 +76,7 @@ class Foo < Granite::Base
     field date_added : Time
 
     def after_initialize
-    	@date_added = Time.utc_now
+    	@date_added = Time.utc
     end
 end
    ```

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -11,7 +11,7 @@ posts = Post.where(published: true, author_id: User.first!.id)
 
 It supports different operators:
 ```crystal
-Post.where(:created_at, :gt, Time.now - 7.days)
+Post.where(:created_at, :gt, Time.local - 7.days)
 ```
 
 Supported operators are :eq, :gteq, :lteq, :neq, :gt, :lt, :nlt, :ngt, :ltgt, :in, :nin, :like, :nlike

--- a/docs/yaml_support.md
+++ b/docs/yaml_support.md
@@ -74,7 +74,7 @@ class Foo < Granite::Base
     field date_added : Time
 
     def after_initialize
-    	@date_added = Time.utc_now
+    	@date_added = Time.utc
     end
 end
    ```

--- a/shard.yml
+++ b/shard.yml
@@ -2,7 +2,7 @@ name: granite
 
 version: 0.15.2
 
-crystal: 0.27.0
+crystal: 0.28.0
 
 authors:
   - drujensen <drujensen@gmail.com>
@@ -18,16 +18,16 @@ dependencies:
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.5.0
+    version: ~> 0.6.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.10.0
+    version: ~> 0.11.0
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.15.0
+    version: ~> 0.16.0
 
   ameba:
     github: veelenga/ameba
-    version: ~> 0.7.0
+    version: ~> 0.9.0

--- a/spec/granite/associations/belongs_to_spec.cr
+++ b/spec/granite/associations/belongs_to_spec.cr
@@ -75,7 +75,7 @@ describe "belongs_to" do
     book.name = "Introduction to Granite"
     book.publisher = publisher
     book.save
-    book.to_json.should eq %({"id":4,"name":"Introduction to Granite"})
+    book.to_json.should eq %({"id":#{book.id},"name":"Introduction to Granite"})
   end
 
   it "supports yaml_options" do
@@ -87,7 +87,7 @@ describe "belongs_to" do
     book.name = "Introduction to Granite"
     book.publisher = publisher
     book.save
-    book.to_yaml.should eq %(---\nid: 5\nname: Introduction to Granite\n)
+    book.to_yaml.should eq %(---\nid: #{book.id}\nname: Introduction to Granite\n)
   end
 
   it "provides a method to retrieve parent object that will raise if record is not found" do

--- a/spec/granite/fields/timestamps_spec.cr
+++ b/spec/granite/fields/timestamps_spec.cr
@@ -101,7 +101,7 @@ require "../../spec_helper"
         ]
 
         Parent.import(to_import)
-        import_time = Time.utc_now.at_beginning_of_second
+        import_time = Time.utc.at_beginning_of_second
 
         parent1 = Parent.find_by!(name: "ParentOne")
         parent1.name.should eq "ParentOne"
@@ -114,7 +114,7 @@ require "../../spec_helper"
         sleep 1
 
         Parent.import(to_update, update_on_duplicate: true, columns: ["name"])
-        update_time = Time.utc_now.at_beginning_of_second
+        update_time = Time.utc.at_beginning_of_second
 
         parent1_edited = Parent.find_by!(name: "ParentOneEdited")
         parent1_edited.name.should eq "ParentOneEdited"

--- a/spec/granite/querying/from_sql_spec.cr
+++ b/spec/granite/querying/from_sql_spec.cr
@@ -11,7 +11,7 @@ macro build_review_emitter
         nil,   # sentiment
         nil,   # interest
         true,  # published
-        Time.now, # created_at
+        Time.local, # created_at
       ]
     )
   end

--- a/spec/granite/transactions/touch_spec.cr
+++ b/spec/granite/transactions/touch_spec.cr
@@ -20,12 +20,12 @@ describe "#touch" do
   end
 
   it "updates updated_at on an object" do
-    old_time = Time.utc_now.at_beginning_of_second
+    old_time = Time.utc.at_beginning_of_second
     object = TimeTest.create(test: old_time)
 
     sleep 3
 
-    new_time = Time.utc_now.at_beginning_of_second
+    new_time = Time.utc.at_beginning_of_second
     object.touch
 
     object.updated_at.should eq new_time
@@ -34,12 +34,12 @@ describe "#touch" do
   end
 
   it "updates updated_at + custom fields on an object" do
-    old_time = Time.utc_now.at_beginning_of_second
+    old_time = Time.utc.at_beginning_of_second
     object = TimeTest.create(test: old_time)
 
     sleep 3
 
-    new_time = Time.utc_now.at_beginning_of_second
+    new_time = Time.utc.at_beginning_of_second
     object.touch("test")
 
     object.updated_at.should eq new_time

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -38,7 +38,7 @@ describe "#update" do
       saved_parent = Parent.find!(parent.id)
       saved_parent.name.should eq "New New Parent"
       saved_parent.created_at.should eq created_at
-      saved_parent.updated_at.should eq Time.utc_now.at_beginning_of_second
+      saved_parent.updated_at.should eq Time.utc.at_beginning_of_second
     end
   end
 end

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -86,7 +86,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   end
 
   private def last_val
-    return "SELECT LAST_INSERT_ROWID()"
+    "SELECT LAST_INSERT_ROWID()"
   end
 
   # This will update a row in the database.

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -35,7 +35,7 @@ module Granite::Querying
         rows << from_sql(results)
       end
     end
-    return rows
+    rows
   end
 
   # All will return all rows in the database. The clause allows you to specify

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -73,7 +73,7 @@ module Granite::Transactions
       end
     end
 
-    disable_granite_docs? def set_timestamps(*, to time = Time.now(Granite.settings.default_timezone), mode = :create)
+    disable_granite_docs? def set_timestamps(*, to time = Time.local(Granite.settings.default_timezone), mode = :create)
       {% if FIELDS.keys.stringify.includes? "created_at" %}
         if mode == :create
           @created_at = time.at_beginning_of_second
@@ -227,7 +227,7 @@ module Granite::Transactions
       fields.each do |field|
         case field.to_s
           {% for time_field in @type.instance_vars.select { |ivar| ivar.type == Time? } %}
-            when {{time_field.stringify}} then @{{time_field.id}} = Time.now(Granite.settings.default_timezone).at_beginning_of_second
+            when {{time_field.stringify}} then @{{time_field.id}} = Time.local(Granite.settings.default_timezone).at_beginning_of_second
           {% end %}
         else
           if {{@type.instance_vars.map(&.name.stringify)}}.includes? field.to_s
@@ -238,7 +238,7 @@ module Granite::Transactions
         end
       end
     {% end %}
-    @updated_at = Time.now(Granite.settings.default_timezone).at_beginning_of_second
+    @updated_at = Time.local(Granite.settings.default_timezone).at_beginning_of_second
     save
   end
 


### PR DESCRIPTION
* Updates Dockerfile to `0.28.0` for CI
* Updates deprecated references of `Time.utc_now` and `Time.now` (#329)
* Updates docker-compose file to show all deprecation warnings
  * Also will error on something being deprecated.  I could go either way if we want CI to fail or not if something becomes deprecated.  Thoughts @drujensen @robacarp @amberframework/granite?
