### PR TITLE
Disallow union types

### DIFF
--- a/src/granite/fields.cr
+++ b/src/granite/fields.cr
@@ -14,6 +14,7 @@ module Granite::Fields
 
   # specify the fields you want to define and types
   macro field(decl, **options)
+    {% raise "The type of #{@type.name}##{decl.var} cannot be a Union.  The 'field' macro declares the type as nilable by default.  Use the 'field!' macro to declare a not nilable field." if decl.type.is_a? Union %}
     {% CONTENT_FIELDS[decl.var] = options || {} of Nil => Nil %}
     {% CONTENT_FIELDS[decl.var][:type] = decl.type %}
   end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -28,6 +28,7 @@ module Granite::Table
   end
 
   macro primary(decl, **options)
+    {% raise "The type of #{@type.name}##{decl.var} cannot be a Union.  The 'primary' macro declares the type as nilable by default." if decl.type.is_a? Union %}
     {% PRIMARY[:name] = decl.var %}
     {% PRIMARY[:type] = decl.type %}
     {% PRIMARY[:auto] = ([true, false, :uuid].includes? options[:auto]) ? options[:auto] : true %}


### PR DESCRIPTION
Resolves #340 

```cr
...
in spec/spec_helper.cr:16: while requiring "./spec_models"

require "./spec_models"
^

in spec/spec_models.cr:8: The type of Teacher#id cannot be a Union.  The 'primary' macro declares the type as nilable by default.

{% begin %}
^
```
```cr
...
in spec/spec_helper.cr:16: while requiring "./spec_models"

require "./spec_models"
^

in spec/spec_models.cr:8: The type of Teacher#age cannot be a Union.  The 'field' macro declares they type as nilable by default.  Use the 'field!' macro to declare a not nilable field.

{% begin %}
```

