### PR TITLE
replace @@var with their getter

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -1,7 +1,25 @@
 require "./spec_helper"
 require "logger"
 
+class SomeClass
+  def initialize(@model : Granite::Base.class); end
+
+  def valid? : Bool
+    @model.exists? 123
+  end
+
+  def table : String
+    @model.table_name
+  end
+end
+
 describe Granite::Base do
+  it "class methods should work when type restricted to `Granite::Base`" do
+    f = SomeClass.new(Teacher)
+    f.valid?.should be_false
+    f.table.should eq "teachers"
+  end
+
   describe "instantiation" do
     describe "with default values" do
       it "should instaniate correctly" do

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -30,7 +30,7 @@ module Granite::Querying
 
   def raw_all(clause = "", params = [] of Granite::Fields::Type)
     rows = [] of self
-    @@adapter.select(@@select, clause, params) do |results|
+    adapter.select(select_container, clause, params) do |results|
       results.each do
         rows << from_sql(results)
       end
@@ -61,12 +61,12 @@ module Granite::Querying
 
   # find returns the row with the primary key specified. Otherwise nil.
   def find(value)
-    first("WHERE #{@@primary_name} = ?", value)
+    first("WHERE #{primary_name} = ?", value)
   end
 
   # find returns the row with the primary key specified. Otherwise raises an exception.
   def find!(value)
-    find(value) || raise Granite::Querying::NotFound.new("No #{{{@type.name.stringify}}} found where #{@@primary_name} = #{value}")
+    find(value) || raise Granite::Querying::NotFound.new("No #{{{@type.name.stringify}}} found where #{primary_name} = #{value}")
   end
 
   # Returns the first row found that matches *criteria*. Otherwise `nil`.
@@ -114,7 +114,7 @@ module Granite::Querying
   # Returns `true` if a records exists with a PK of *id*, otherwise `false`.
   def exists?(id : Number | String | Nil) : Bool
     return false if id.nil?
-    exec_exists "#{@@primary_name} = ?", [id]
+    exec_exists "#{primary_name} = ?", [id]
   end
 
   # Returns `true` if a records exists that matches *criteria*, otherwise `false`.
@@ -133,19 +133,19 @@ module Granite::Querying
   end
 
   def exec(clause = "")
-    @@adapter.open { |db| db.exec(clause) }
+    adapter.open { |db| db.exec(clause) }
   end
 
   def query(clause = "", params = [] of Granite::Fields::Type, &block)
-    @@adapter.open { |db| yield db.query(clause, params) }
+    adapter.open { |db| yield db.query(clause, params) }
   end
 
   def scalar(clause = "", &block)
-    @@adapter.open { |db| yield db.scalar(clause) }
+    adapter.open { |db| yield db.scalar(clause) }
   end
 
   private def exec_exists(clause : String, params : Array(Granite::Fields::Type)) : Bool
-    @@adapter.exists? quoted_table_name, clause, params
+    adapter.exists? quoted_table_name, clause, params
   end
 
   private def build_find_by_clause(criteria : Hash(Symbol | String, Granite::Fields::Type))

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -16,6 +16,10 @@ module Granite::Select
   end
 
   macro __process_select
-    @@select = Container.new(table_name: @@table_name, fields: fields)
+    @@select = Container.new(table_name: self.table_name, fields: fields)
+
+    def self.select_container : Container
+      @@select
+    end
   end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -42,33 +42,28 @@ module Granite::Table
     {% primary_type = PRIMARY[:type] %}
     {% primary_auto = PRIMARY[:auto] %}
 
-    @@table_name = "{{table_name}}"
-    @@primary_name = "{{primary_name}}"
-    @@primary_auto = "{{primary_auto}}"
-    @@primary_type = {{primary_type}}
-
-    disable_granite_docs? def self.table_name
-      @@table_name
+    disable_granite_docs? def self.table_name : String
+      {{table_name.stringify}}
     end
 
-    disable_granite_docs? def self.primary_name
-      @@primary_name
+    disable_granite_docs? def self.primary_name : String
+      {{primary_name.stringify}}
     end
 
     disable_granite_docs? def self.primary_type
-      @@primary_type
+      {{primary_type}}
     end
 
-    disable_granite_docs? def self.primary_auto
-      @@primary_auto
+    disable_granite_docs? def self.primary_auto : String
+      {{primary_auto.stringify}}
     end
 
-    disable_granite_docs? def self.quoted_table_name
-      @@adapter.quote(table_name)
+    disable_granite_docs? def self.quoted_table_name : String
+      adapter.quote(table_name)
     end
 
-    disable_granite_docs? def self.quote(column_name)
-      @@adapter.quote(column_name)
+    disable_granite_docs? def self.quote(column_name) : String
+      adapter.quote(column_name)
     end
   end
 end


### PR DESCRIPTION
I discovered this when working on another project.  The jist of it is when restricting an ivar to `Granite::Base`, the compiler will complain that

```cr
can't infer the type of class variable '@@primary_name' of Granite::Base.class
    exec_exists "#{@@primary_name} = ?", [id]
```

I'm guessing that since we're operating on the class level and these class vars get set via the macro included/finished hooks, they are not set.  However using the class getters gets around that since their types are known and not reliant on the actual setting of the value.