### PR TITLE
Upgrade to Crystal v0.30.0

### DIFF
--- a/spec/granite/converters/uuid_spec.cr
+++ b/spec/granite/converters/uuid_spec.cr
@@ -25,7 +25,11 @@ describe Granite::Converters::Uuid do
     describe ".to_db" do
       it "should convert a UUID enum into Bytes" do
         uuid = UUID.random
-        Granite::Converters::Uuid(Bytes).to_db(uuid).should eq uuid.to_slice
+        {% if compare_versions(Crystal::VERSION, "0.30.0-0") >= 0 %}
+          Granite::Converters::Uuid(Bytes).to_db(uuid).should eq uuid.bytes.to_slice
+        {% else %}
+          Granite::Converters::Uuid(Bytes).to_db(uuid).should eq uuid.to_slice
+        {% end %}
       end
     end
 
@@ -34,7 +38,11 @@ describe Granite::Converters::Uuid do
         uuid = UUID.new "cfe37f98-fdbf-43a3-b3d8-9c3288fb9ba6"
 
         rs = FieldEmitter.new.tap do |e|
-          e._set_values([uuid.to_slice])
+          {% if compare_versions(Crystal::VERSION, "0.30.0-0") >= 0 %}
+            e._set_values([uuid.bytes.to_slice])
+          {% else %}
+            e._set_values([uuid.to_slice])
+          {% end %}
         end
 
         Granite::Converters::Uuid(Bytes).from_rs(rs).should eq uuid

--- a/spec/mocks/db_mock.cr
+++ b/spec/mocks/db_mock.cr
@@ -3,7 +3,7 @@ class FakeStatement < DB::Statement
     FieldEmitter.new
   end
 
-  protected def perform_exec(args : Enumerable)
+  protected def perform_exec(args : Enumerable) : DB::ExecResult
     DB::ExecResult.new 0_i64, 0_i64
   end
 end
@@ -11,11 +11,11 @@ end
 class FakeContext
   include DB::ConnectionContext
 
-  def uri
+  def uri : URI
     URI.new ""
   end
 
-  def prepared_statements?
+  def prepared_statements? : Bool
     false
   end
 
@@ -30,11 +30,11 @@ class FakeConnection < DB::Connection
     @prepared_statements = false
   end
 
-  def build_unprepared_statement(query : String)
+  def build_unprepared_statement(query : String) : FakeStatement
     FakeStatement.new self
   end
 
-  def build_prepared_statement(query : String)
+  def build_prepared_statement(query : String) : FakeStatement
     FakeStatement.new self
   end
 end
@@ -65,9 +65,10 @@ class FieldEmitter < DB::ResultSet
     end
   end
 
-  def move_next
+  def move_next : Bool
     @position += 1
     @field_position = 0
+    @position < @values.size
   end
 
   def read
@@ -80,11 +81,11 @@ class FieldEmitter < DB::ResultSet
     end
   end
 
-  def column_count
+  def column_count : Int32
     @values.size
   end
 
-  def column_name(index : Int32)
+  def column_name(index : Int32) : String
     "Column #{index}"
   end
 end

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -30,7 +30,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     log statement, elapsed_time
   end
 
-  def insert(table_name : String, fields, params, lastval)
+  def insert(table_name : String, fields, params, lastval) : Int64
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -39,7 +39,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     log statement, elapsed_time
   end
 
-  def insert(table_name : String, fields, params, lastval)
+  def insert(table_name : String, fields, params, lastval) : Int64
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -31,7 +31,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     log statement, elapsed_time
   end
 
-  def insert(table_name : String, fields, params, lastval)
+  def insert(table_name : String, fields, params, lastval) : Int64
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")

--- a/src/granite/converters.cr
+++ b/src/granite/converters.cr
@@ -10,7 +10,13 @@ module Granite::Converters
       {% if T == String %}
         value.to_s
       {% elsif T == Bytes %}
-        value.to_slice.dup
+        {% if compare_versions(Crystal::VERSION, "0.30.0-0") >= 0 %}
+          # we need a heap allocated slice
+          v = value.bytes.each.to_a
+          Slice.new(v.to_unsafe, v.size)
+        {% else %}
+          value.to_slice.dup
+        {% end %}
       {% else %}
         {% raise "#{@type.name}#to_db does not support #{T} yet." %}
       {% end %}


### PR DESCRIPTION
This PR adds support for Crystal 0.30.0 without dropping the support for earlier versions.

The fences 0.30.0-0 can be replaces by 0.30.0 after the compiler is released if desired.

Read about `UUID#to_slice` deprecation in https://github.com/crystal-lang/crystal/pull/7901 . I guess the underlying design might need an iteration to have a cleaner implementation, probably without using `Slice` to store a `UUID`.

crystal-db shards will need to be updated also as stated in https://github.com/bcardiff/granite/commit/1d8a77c08dc3bbde4b97b28f0b778b7f7ada0696 after each of them are released. Do not use my forks as dependencies.

* https://github.com/crystal-lang/crystal-db/pull/108
* https://github.com/crystal-lang/crystal-mysql/pull/80
* https://github.com/crystal-lang/crystal-sqlite3/pull/43
* https://github.com/will/crystal-pg/pull/178