### PR TITLE
Allow enums to be used within `#to_h`

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -41,8 +41,7 @@ describe Granite::Base do
 
     describe "with a hash" do
       it "should instaniate correctly" do
-        hash = {"name" => "Bob", "age" => 3.14}
-        model = DefaultValues.new hash
+        model = DefaultValues.new({"name" => "Bob", "age" => 3.14})
         model.name.should eq "Bob"
         model.age.should eq 3.14
         model.is_alive.should be_true
@@ -62,8 +61,7 @@ describe Granite::Base do
 
     describe "with string numeric values" do
       it "should instaniate correctly" do
-        hash = {"user_id" => "1", "int32" => "17", "float32" => "3.14", "float" => "92342.2342342"}
-        model = StringConversion.new hash
+        model = StringConversion.new({"user_id" => "1", "int32" => "17", "float32" => "3.14", "float" => "92342.2342342"})
 
         model.user_id.should be_a Int64
         model.user_id.should eq 1
@@ -112,7 +110,7 @@ describe Granite::Base do
         review = Review.from_json(json_str)
         review.name.should eq "json::anyReview"
         review.upvotes.should eq 2
-        review.sentiment.should eq 1.23.to_f32
+        review.sentiment.should eq 1.23_f32
         review.interest.should eq 4.56
         review.published.should eq true
         review.created_at.should be_nil
@@ -124,14 +122,14 @@ describe Granite::Base do
         review = Array(Review).from_json(json_str)
         review[0].name.should eq "json1"
         review[0].upvotes.should eq 2
-        review[0].sentiment.should eq 1.23.to_f32
+        review[0].sentiment.should eq 1.23_f32
         review[0].interest.should eq 4.56
         review[0].published.should be_true
         review[0].created_at.should be_nil
 
         review[1].name.should eq "json2"
         review[1].upvotes.should eq 0
-        review[1].sentiment.should eq 5.00.to_f32
+        review[1].sentiment.should eq 5.00_f32
         review[1].interest.should eq 6.99
         review[1].published.should be_false
         review[1].created_at.should be_nil
@@ -326,6 +324,12 @@ describe Granite::Base do
       s = Item.new(item_name: "Hacker News")
       s.item_id = "three"
       s.to_h.should eq({"item_name" => "Hacker News", "item_id" => "three"})
+    end
+
+    it "works with enums" do
+      model = EnumModel.new
+      model.my_enum = MyEnum::One
+      model.to_h.should eq({"id" => nil, "my_enum" => MyEnum::One})
     end
   end
 

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -493,6 +493,14 @@ end
     Four
   end
 
+  class EnumModel < Granite::Base
+    connection {{ adapter_literal }}
+    table enum_model
+
+    column id : Int64, primary: true
+    column my_enum : MyEnum?, column_type: "TEXT", converter: Granite::Converters::Enum(MyEnum, String)
+  end
+
   {% if env("CURRENT_ADAPTER") == "pg" %}
     class ConverterModel < Granite::Base
       connection {{ adapter_literal }}

--- a/src/granite/columns.cr
+++ b/src/granite/columns.cr
@@ -59,7 +59,7 @@ module Granite::Columns
     # Raise an exception if the delc type has more than 2 union types or if it has 2 types without nil
     # This prevents having a column typed to String | Int32 etc.
     {% if type.is_a?(Union) && (type.types.size > 2 || (type.types.size == 2 && !type.types.any?(&.resolve.nilable?))) %}
-      {% raise "The type of #{@type.name}##{decl.var} cannot be a Union.  The 'field' macro declares the type as nilable by default.  Use the 'field!' macro to declare a not nilable field." %}
+      {% raise "The column #{@type.name}##{decl.var} cannot consist of a Union with a type other than `Nil`." %}
     {% end %}
 
     {% column_type = (options[:column_type] && !options[:column_type].nil?) ? options[:column_type] : nil %}
@@ -101,7 +101,7 @@ module Granite::Columns
   end
 
   def to_h
-    fields = {} of String => Type
+    fields = {{"Hash(String, Union(#{@type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) }.map(&.type.id).splat})).new".id}}
 
     {% for column in @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) } %}
         {% if column.type.id == Time.id %}

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -114,7 +114,7 @@ module Granite::Transactions
           fields << {{primary_key.name.stringify}}
           self.class.adapter.insert(self.class.table_name, fields, params, lastval: nil)
       {% elsif ann[:auto] == true %}
-        {% raise "Failed to define #{@type.name}#save: Primary key must be Int(32|64) or UUID, or set `auto: false` for natural keys.\n\n  primary #{primary_key.name} : #{primary_key.type}, auto: false\n" %}
+        {% raise "Failed to define #{@type.name}#save: Primary key must be Int(32|64) or UUID, or set `auto: false` for natural keys.\n\n  column #{primary_key.name} : #{primary_key.type}, primary: true, auto: false\n" %}
       {% else %}
         if @{{primary_key.name.id}}
           self.class.adapter.insert(self.class.table_name, fields, params, lastval: nil)


### PR DESCRIPTION
Fix some compile error messages

**Issue:** https://github.com/amberframework/granite/issues/361

EDIT:  I should also mention this makes it so the type of the resulting hash now only consists of the types of the model's columns.  I.e. if a model does not define a `Time` column, then there wouldn't be `Time` in the type union.