### PR TITLE
Handle `false` when a column has a default value

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -20,6 +20,16 @@ describe Granite::Base do
     f.table.should eq "teachers"
   end
 
+  it "should allow false as a column value" do
+    model = BoolModel.create active: false
+
+    model.active.should be_false
+    model.id.should eq 1
+
+    fetched_model = BoolModel.find! model.id
+    fetched_model.active.should be_false
+  end
+
   describe "instantiation" do
     describe "with default values" do
       it "should instaniate correctly" do

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -476,6 +476,14 @@ end
     column float : Float64
   end
 
+  class BoolModel < Granite::Base
+    connection {{ adapter_literal }}
+    table "bool_model"
+
+    column id : Int64, primary: true
+    column active : Bool = true
+  end
+
   struct MyType
     include JSON::Serializable
 

--- a/src/granite/columns.cr
+++ b/src/granite/columns.cr
@@ -43,7 +43,13 @@ module Granite::Columns
             @{{column.id}} = {% if ann[:converter] %}
               {{ann[:converter]}}.from_rs result
             {% else %}
-              Granite::Type.from_rs(result, {{ann[:nilable] ? column.type : column.type.union_types.reject { |t| t == Nil }.first}}) {% if column.has_default_value? && !column.default_value.nil? %} || {{column.default_value}} {% end %}
+              value = Granite::Type.from_rs(result, {{ann[:nilable] ? column.type : column.type.union_types.reject { |t| t == Nil }.first}})
+
+              {% if column.has_default_value? && !column.default_value.nil? %}
+                return {{column.default_value}} if value.nil?
+              {% end %}
+
+              value
             {% end %}
         {% end %}
         end


### PR DESCRIPTION
Fixes #373

the previous `||` based logic for returning default values was flawed since `false` is a valid value but would cause the default to be returned.