### PR TITLE
Association improvements

### DIFF
--- a/spec/granite/associations/belongs_to_spec.cr
+++ b/spec/granite/associations/belongs_to_spec.cr
@@ -143,4 +143,18 @@ describe "belongs_to" do
 
     courier.service!.owner_id.should eq 123_321
   end
+
+  it "works with includes that preloads parents" do
+    ids = Array(Int64).new(3) do
+      teacher = Teacher.create(name: "teacher for includes")
+      klass = Klass.new(name: "class for includes")
+      klass.teacher = teacher
+      klass.save
+      teacher.id!
+    end
+
+    Klass.includes(:teacher).where(name: "class for includes").order(:teacher_id).select.each_with_index do |klass, i|
+      klass.@teacher.not_nil!.id.should eq ids[i]
+    end
+  end
 end

--- a/spec/granite/associations/belongs_to_spec.cr
+++ b/spec/granite/associations/belongs_to_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
 describe "belongs_to" do
-  it "provides a getter for the foreign entity" do
+  it "provides getters for the foreign entity" do
     teacher = Teacher.new
     teacher.name = "Test teacher"
     teacher.save
@@ -12,6 +12,33 @@ describe "belongs_to" do
     klass.save
 
     klass.teacher.id.should eq teacher.id
+    klass.teacher?.try(&.id).should eq teacher.id
+  end
+
+  it "provides getters that return cached foreign entity" do
+    teacher = Teacher.new
+    teacher.name = "Test teacher"
+    teacher.save
+
+    klass = Klass.new
+    klass.name = "Test klass"
+    klass.teacher_id = teacher.id
+    klass.save
+
+    klass.teacher.hash.should eq klass.teacher?.hash
+  end
+
+  it "provides a method to reload cache" do
+    teacher = Teacher.new
+    teacher.name = "Test teacher"
+    teacher.save
+
+    klass = Klass.new
+    klass.name = "Test klass"
+    klass.teacher_id = teacher.id
+    klass.save
+
+    klass.teacher.hash.should_not eq klass.reload_teacher.hash
   end
 
   it "provides a setter for the foreign entity" do
@@ -63,7 +90,7 @@ describe "belongs_to" do
     book.publisher = publisher
     book.save
 
-    book.publisher.name.should eq "Amber Framework"
+    book.publisher!.name.should eq "Amber Framework"
   end
 
   it "supports json_options" do
@@ -91,9 +118,13 @@ describe "belongs_to" do
   end
 
   it "provides a method to retrieve parent object that will raise if record is not found" do
+    klass = Klass.new
+    klass.name = "Test klass"
+
     book = Book.new
     book.name = "Introduction to Granite"
 
+    expect_raises Granite::Querying::NotFound, "No Teacher found where id is NULL" { klass.teacher }
     expect_raises Granite::Querying::NotFound, "No Company found where id is NULL" { book.publisher! }
   end
 

--- a/spec/granite/associations/has_many_spec.cr
+++ b/spec/granite/associations/has_many_spec.cr
@@ -23,6 +23,52 @@ describe "has_many" do
     teacher.klasses.size.should eq 2
   end
 
+  it "provides a getter that returns cached associated objects" do
+    teacher = Teacher.new
+    teacher.name = "test teacher"
+    teacher.save
+
+    class1 = Klass.new
+    class1.name = "Test class 1"
+    class1.teacher = teacher
+    class1.save
+
+    class2 = Klass.new
+    class2.name = "Test class 2"
+    class2.teacher = teacher
+    class2.save
+
+    class3 = Klass.new
+    class3.name = "Test class 3"
+    class3.save
+
+    teacher.klasses.hash.should eq teacher.klasses.hash
+    teacher.klasses.all.hash.should eq teacher.klasses.all.hash
+  end
+
+  it "provides a method to reload cache" do
+    teacher = Teacher.new
+    teacher.name = "test teacher"
+    teacher.save
+
+    class1 = Klass.new
+    class1.name = "Test class 1"
+    class1.teacher = teacher
+    class1.save
+
+    class2 = Klass.new
+    class2.name = "Test class 2"
+    class2.teacher = teacher
+    class2.save
+
+    class3 = Klass.new
+    class3.name = "Test class 3"
+    class3.save
+
+    teacher.klasses.hash.should_not eq teacher.reload_klasses.hash
+    teacher.klasses.all.hash.should_not eq teacher.reload_klasses.all.hash
+  end
+
   context "querying association" do
     it "#all" do
       teacher = Teacher.new

--- a/spec/granite/associations/has_many_spec.cr
+++ b/spec/granite/associations/has_many_spec.cr
@@ -67,6 +67,7 @@ describe "has_many" do
 
     teacher.klasses.hash.should_not eq teacher.reload_klasses.hash
     teacher.klasses.all.hash.should_not eq teacher.reload_klasses.all.hash
+    teacher.klasses.all.hash.should_not eq teacher.klasses.reload.hash
   end
 
   context "querying association" do

--- a/spec/granite/associations/has_one_spec.cr
+++ b/spec/granite/associations/has_one_spec.cr
@@ -14,7 +14,7 @@ describe "has_one" do
     profile.user_id.should eq profile.id
   end
 
-  it "provides a method to retrieve associated objects" do
+  it "provides getters to retrieve associated object" do
     profile = Profile.new
     profile.name = "Test Profile"
     profile.save
@@ -27,16 +27,54 @@ describe "has_one" do
     user.profile = profile
     profile.save
 
-    retrieved_profile = user.profile!
-    retrieved_profile.id.should eq profile.id
+    user.profile?.try(&.id).should eq profile.id
+    user.profile.id.should eq profile.id
   end
 
-  it "provides a method to retrieve associated object that will raise if record is not found" do
+  it "provides getters that return cached object" do
+    profile = Profile.new
+    profile.name = "Test Profile"
+    profile.save
+
     user = User.new
     user.email = "test@domain.com"
     user.save
 
-    expect_raises Granite::Querying::NotFound, "No Profile found where user_id = 3" { user.profile! }
+    # profile's foriegn_key is now set, so calling save again
+    user.profile = profile
+    profile.save
+
+    user.profile.hash.should eq user.profile.hash
+  end
+
+  it "provides a method to reload cache" do
+    profile = Profile.new
+    profile.name = "Test Profile"
+    profile.save
+
+    user = User.new
+    user.email = "test@domain.com"
+    user.save
+
+    # profile's foriegn_key is now set, so calling save again
+    user.profile = profile
+    profile.save
+
+    user.profile.hash.should_not eq user.reload_profile.hash
+  end
+
+  it "provides a method to retrieve associated object that will raise if record is not found" do
+    courier = Courier.new
+    courier.courier_id = 94
+    courier.issuer_id = 87
+    courier.save
+
+    user = User.new
+    user.email = "test@domain.com"
+    user.save
+
+    expect_raises Granite::Querying::NotFound, "No Character found where character_id = 87" { courier.issuer! }
+    expect_raises Granite::Querying::NotFound, "No Profile found where user_id = 5" { user.profile }
   end
 
   it "provides the ability to use a custom primary key" do

--- a/spec/granite/associations/has_one_spec.cr
+++ b/spec/granite/associations/has_one_spec.cr
@@ -92,4 +92,18 @@ describe "has_one" do
 
     courier.issuer!.character_id.should eq 999
   end
+
+  it "works with includes that preloads children" do
+    ids = Array(Int64).new(3) do
+      user = User.create(email: "user@for.includes")
+      profile = Profile.new(name: "profile for includes")
+      user.profile = profile
+      profile.save
+      profile.id!
+    end
+
+    User.where(email: "user@for.includes").order(:id).includes(:profile).select.each_with_index do |user, i|
+      user.@profile.not_nil!.id.should eq ids[i]
+    end
+  end
 end

--- a/spec/granite/query/builder_spec.cr
+++ b/spec/granite/query/builder_spec.cr
@@ -38,6 +38,13 @@ describe Granite::Query::Builder(Model) do
     query.where_fields.should eq expected
   end
 
+  it "stores includes" do
+    query = builder.includes(:children).includes(:parent)
+    expected = Set{:children, :parent}
+
+    query.includes.should eq expected
+  end
+
   it "stores limit" do
     query = builder.limit(7)
     query.limit.should eq 7

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -101,7 +101,7 @@ end
     column issuer_id : Int32
 
     belongs_to service : CourierService?, primary_key: "owner_id"
-    has_one issuer : Character, primary_key: "issuer_id", foreign_key: "character_id"
+    has_one issuer : Character?, primary_key: "issuer_id", foreign_key: "character_id"
   end
 
   class CourierService < Granite::Base

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -100,7 +100,7 @@ end
     column courier_id : Int32, primary: true, auto: false
     column issuer_id : Int32
 
-    belongs_to service : CourierService, primary_key: "owner_id"
+    belongs_to service : CourierService?, primary_key: "owner_id"
     has_one issuer : Character, primary_key: "issuer_id", foreign_key: "character_id"
   end
 
@@ -229,7 +229,7 @@ end
 
     @[JSON::Field(ignore: true)]
     @[YAML::Field(ignore: true)]
-    belongs_to publisher : Company, foreign_key: publisher_id : Int32?
+    belongs_to publisher : Company?, foreign_key: publisher_id : Int32?
     has_many :book_reviews, class_name: BookReview
     belongs_to author : Person
   end

--- a/src/granite/association_collection.cr
+++ b/src/granite/association_collection.cr
@@ -10,6 +10,11 @@ class Granite::AssociationCollection(Owner, Target)
     @collection ||= Target.all(query, [owner.primary_key_value])
   end
 
+  def reload
+    @collection = nil
+    all
+  end
+
   def all(clause, params = [] of DB::Any)
     Target.all(
       [query, clause].join(" "),

--- a/src/granite/association_collection.cr
+++ b/src/granite/association_collection.cr
@@ -1,10 +1,16 @@
 class Granite::AssociationCollection(Owner, Target)
   forward_missing_to all
 
+  @collection : Collection(Target)?
+
   def initialize(@owner : Owner, @foreign_key : (Symbol | String), @through : (Symbol | String | Nil) = nil)
   end
 
-  def all(clause = "", params = [] of DB::Any)
+  def all
+    @collection ||= Target.all(query, [owner.primary_key_value])
+  end
+
+  def all(clause, params = [] of DB::Any)
     Target.all(
       [query, clause].join(" "),
       [owner.primary_key_value] + params

--- a/src/granite/associations.cr
+++ b/src/granite/associations.cr
@@ -1,36 +1,57 @@
 module Granite::Associations
   macro belongs_to(model, **options)
-    {% if model.is_a? TypeDeclaration %}
-      {% method_name = model.var %}
-      {% class_name = model.type %}
-    {% else %}
-      {% method_name = model.id %}
-      {% class_name = options[:class_name] || model.id.camelcase %}
-    {% end %}
+    {%
+      nilable = false
+      if model.is_a? TypeDeclaration
+        name = model.var.id
+        type = model.type
+      else
+        name = model.id
+        type = options[:class_name] || name.camelcase
+      end
+      if type.is_a? Union
+        nilable = type.types.any?(&.resolve?.== Nil)
+        type = type.types.find(&.resolve?.!= Nil)
+      end
+      if nilable
+        nilable_method = name
+        not_nil_method = name + "!"
+      else
+        nilable_method = name + "?"
+        not_nil_method = name
+      end
+      type = type.id
+    %}
 
     {% if options[:foreign_key] && options[:foreign_key].is_a? TypeDeclaration %}
-      {% foreign_key = options[:foreign_key].var %}
+      {% foreign_key = options[:foreign_key].var.id %}
       column {{options[:foreign_key]}}
     {% else %}
-      {% foreign_key = method_name + "_id" %}
+      {% foreign_key = name + "_id" %}
       column {{foreign_key}} : Int64?
     {% end %}
-    {% primary_key = options[:primary_key] || "id" %}
+    {% primary_key = (options[:primary_key] || "id").id %}
 
-    def {{method_name.id}} : {{class_name.id}}?
-      if parent = {{class_name.id}}.find_by({{primary_key.id}}: {{foreign_key.id}})
-        parent
-      else
-        {{class_name.id}}.new
-      end
+    @[JSON::Field(ignore: true)]
+    @[YAML::Field(ignore: true)]
+    @{{name}} : {{type}}?
+
+    def {{nilable_method}} : {{type}}?
+      @{{name}} ||= {{type}}.find_by({{primary_key}}: {{foreign_key}})
     end
 
-    def {{method_name.id}}! : {{class_name.id}}
-      {{class_name.id}}.find_by!({{primary_key.id}}: {{foreign_key.id}})
+    def {{not_nil_method}} : {{type}}
+      @{{name}} ||= {{type}}.find_by!({{primary_key}}: {{foreign_key}})
     end
 
-    def {{method_name.id}}=(parent : {{class_name.id}})
-      @{{foreign_key.id}} = parent.{{primary_key.id}}
+    def {{name}}=(parent : {{type}}) : {{type}}
+      @{{foreign_key}} = parent.{{primary_key}}
+      @{{name}} = parent
+    end
+
+    def reload_{{name}} : {{type}}?
+      @{{name}} = nil
+      {{nilable_method}}
     end
   end
 

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -180,7 +180,7 @@ module Granite::Query::Assembler
         s << offset
       end
 
-      Executor::List(Model).new sql, numbered_parameters
+      Executor::List(Model).new sql, numbered_parameters, @query.includes
     end
 
     def exists? : Executor::Value(Model, Bool)

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -31,6 +31,7 @@ class Granite::Query::Builder(Model)
   getter where_fields = [] of NamedTuple(join: Symbol, field: String, operator: Symbol, value: Granite::Columns::Type)
   getter order_fields = [] of NamedTuple(field: String, direction: Sort)
   getter group_fields = [] of NamedTuple(field: String)
+  getter includes = Set(Symbol).new
   getter offset : Int64?
   getter limit : Int64?
 
@@ -160,6 +161,12 @@ class Granite::Query::Builder(Model)
     dsl.each do |field|
       @group_fields << {field: field.to_s}
     end
+
+    self
+  end
+
+  def includes(association)
+    @includes << association
 
     self
   end

--- a/src/granite/query/builder_methods.cr
+++ b/src/granite/query/builder_methods.cr
@@ -12,5 +12,5 @@ module Granite::Query::BuilderMethods
     Builder(self).new(db_type)
   end
 
-  delegate where, order, offset, limit, to: __builder
+  delegate where, includes, order, offset, limit, to: __builder
 end

--- a/src/granite/query/executors/list.cr
+++ b/src/granite/query/executors/list.cr
@@ -2,7 +2,7 @@ module Granite::Query::Executor
   class List(Model)
     include Shared
 
-    def initialize(@sql : String, @args = [] of Granite::Columns::Type)
+    def initialize(@sql : String, @args = [] of Granite::Columns::Type, @includes = Set(Symbol).new)
     end
 
     def run : Array(Model)
@@ -16,6 +16,10 @@ module Granite::Query::Executor
             results << Model.from_rs record_set
           end
         end
+      end
+
+      @includes.each do |i|
+        Model::INCLUDERS[i].call(results)
       end
 
       results


### PR DESCRIPTION
## Breaking Changes

1. Define getter based on the nilability like `column`.
    - `getter` and `getter?` for not nil type; `getter!` and `getter` for nilable type
    - only for `belongs_to` and `has_one` (since `has_many` simply returns empty collection if not found)
2. Cache associations.
    - `#reload_{{name}}` to reload
    -  another reload option`#{{name}}.reload` for `has_many`