### PR TITLE
Add a to_json method for Granite::Error

### DIFF
--- a/spec/granite/error/error_spec.cr
+++ b/spec/granite/error/error_spec.cr
@@ -1,0 +1,7 @@
+require "../../spec_helper"
+
+describe Granite::Error do
+  it "should convert to json" do
+    Granite::Error.new("field", "error message").to_json.should eq %({"field":"field","message":"error message"})
+  end
+end

--- a/src/granite/error.cr
+++ b/src/granite/error.cr
@@ -4,6 +4,13 @@ class Granite::Error
   def initialize(@field : (String | Symbol | JSON::Any), @message : String? = "")
   end
 
+  def to_json(builder : JSON::Builder)
+    builder.object do
+      builder.field "field", @field
+      builder.field "message", @message
+    end
+  end
+
   def to_s(io)
     if field == :base
       io << message


### PR DESCRIPTION
I wasn't sure if this was something that was at all wanted, so I figured I'd send a PR to be safe.

This PR manually defines a `to_json` method for `Granite::Error`. We can't `include JSON::Serializable` due to the type of `Granite::Error.field`, so a manual solution is required.