### PR TITLE
Support custom queries in builder

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -16,10 +16,11 @@ Post.where(:created_at, :gt, Time.local - 7.days)
 
 Supported operators are :eq, :gteq, :lteq, :neq, :gt, :lt, :nlt, :ngt, :ltgt, :in, :nin, :like, :nlike
 
-Alternatively, where accepts a raw SQL clause, with "?" as a placeholder to avoid SQL Injection.
+Alternatively, `#where`, `#and`, and `#or` accept a raw SQL clause, with an optional placeholder (`?` for MySQL/SQLite, `$` for Postgres) to avoid SQL Injection.
 ```crystal
+# Example using Postgres adapter
 Post.where(:created_at, :gt, Time.local - 7.days)
-  .where("LOWER(author_name) = ?", name)
+  .where("LOWER(author_name) = $", name)
   .where("tags @> '{"Journal", "Book"}') # PG's array contains operator
 ```
 This is useful for building more sophisticated queries, including queries dependent on database specific features not supported by the operators above. However, **clauses built with this method are not validated.**

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -16,6 +16,13 @@ Post.where(:created_at, :gt, Time.local - 7.days)
 
 Supported operators are :eq, :gteq, :lteq, :neq, :gt, :lt, :nlt, :ngt, :ltgt, :in, :nin, :like, :nlike
 
+Alternatively, where accepts a raw SQL clause, with "?" as a placeholder to avoid SQL Injection. This is useful for building more sophisticated queries, including queries dependent on database specific features not supported by the operators above. However, **clauses built with this method are not validated.**
+```crystal
+Post.where(:created_at, :gt, Time.local - 7.days)
+  .where("LOWER(author_name) = ?", name)
+  .where("tags @> '{"Journal", "Book"}') # PG's array contains operator
+```
+
 ## Order
 
 Order is using the QueryBuilder and supports providing an ORDER BY clause:

--- a/spec/granite/query/assemblers/mysql_spec.cr
+++ b/spec/granite/query/assemblers/mysql_spec.cr
@@ -77,14 +77,14 @@ require "../spec_helper"
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
 
-      it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = 'bob' and age = ? order by id desc"
-        query = builder.where("name = 'bob'").where("age = ?", 23)
+      it "handles raw SQL" do
+        sql = "select #{query_fields} from table where name = 'bob' and age = ? and color = ? order by id desc"
+        query = builder.where("name = 'bob'").where("age = ?", 23).where("color = ?", "red")
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq [23]
+        assembler.numbered_parameters.should eq [23, "red"]
       end
     end
 

--- a/spec/granite/query/assemblers/mysql_spec.cr
+++ b/spec/granite/query/assemblers/mysql_spec.cr
@@ -76,6 +76,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
+
+      it "handles custom SQL" do
+        sql = "select #{query_fields} from table where name = ? and age = ? order by id desc"
+        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq ["bob", 23]
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/mysql_spec.cr
+++ b/spec/granite/query/assemblers/mysql_spec.cr
@@ -78,13 +78,13 @@ require "../spec_helper"
       end
 
       it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = ? and age = ? order by id desc"
-        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        sql = "select #{query_fields} from table where name = 'bob' and age = ? order by id desc"
+        query = builder.where("name = 'bob'").where("age = ?", 23)
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq ["bob", 23]
+        assembler.numbered_parameters.should eq [23]
       end
     end
 

--- a/spec/granite/query/assemblers/pg_spec.cr
+++ b/spec/granite/query/assemblers/pg_spec.cr
@@ -76,6 +76,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
+
+      it "handles custom SQL" do
+        sql = "select #{query_fields} from table where name = $1 and age = $2 order by id desc"
+        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq ["bob", 23]
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/pg_spec.cr
+++ b/spec/granite/query/assemblers/pg_spec.cr
@@ -77,14 +77,14 @@ require "../spec_helper"
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
 
-      it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = 'bob' and age = $1 order by id desc"
-        query = builder.where("name = 'bob'").where("age = ?", 23)
+      it "handles raw SQL" do
+        sql = "select #{query_fields} from table where name = 'bob' and age = $1 and color = $2 order by id desc"
+        query = builder.where("name = 'bob'").where("age = $", 23).where("color = $", "red")
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq [23]
+        assembler.numbered_parameters.should eq [23, "red"]
       end
     end
 

--- a/spec/granite/query/assemblers/pg_spec.cr
+++ b/spec/granite/query/assemblers/pg_spec.cr
@@ -78,13 +78,13 @@ require "../spec_helper"
       end
 
       it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = $1 and age = $2 order by id desc"
-        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        sql = "select #{query_fields} from table where name = 'bob' and age = $1 order by id desc"
+        query = builder.where("name = 'bob'").where("age = ?", 23)
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq ["bob", 23]
+        assembler.numbered_parameters.should eq [23]
       end
     end
 

--- a/spec/granite/query/assemblers/sqlite_spec.cr
+++ b/spec/granite/query/assemblers/sqlite_spec.cr
@@ -77,14 +77,14 @@ require "../spec_helper"
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
 
-      it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = 'bob' and age = ? order by id desc"
-        query = builder.where("name = 'bob'").where("age = ?", 23)
+      it "handles raw SQL" do
+        sql = "select #{query_fields} from table where name = 'bob' and age = ? and color = ? order by id desc"
+        query = builder.where("name = 'bob'").where("age = ?", 23).where("color = ?", "red")
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq [23]
+        assembler.numbered_parameters.should eq [23, "red"]
       end
     end
 

--- a/spec/granite/query/assemblers/sqlite_spec.cr
+++ b/spec/granite/query/assemblers/sqlite_spec.cr
@@ -76,6 +76,16 @@ require "../spec_helper"
         assembler.where
         assembler.numbered_parameters.should eq [] of Granite::Columns::Type
       end
+
+      it "handles custom SQL" do
+        sql = "select #{query_fields} from table where name = ? and age = ? order by id desc"
+        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        query.raw_sql.should match ignore_whitespace sql
+
+        assembler = query.assembler
+        assembler.where
+        assembler.numbered_parameters.should eq ["bob", 23]
+      end
     end
 
     context "order" do

--- a/spec/granite/query/assemblers/sqlite_spec.cr
+++ b/spec/granite/query/assemblers/sqlite_spec.cr
@@ -78,13 +78,13 @@ require "../spec_helper"
       end
 
       it "handles custom SQL" do
-        sql = "select #{query_fields} from table where name = ? and age = ? order by id desc"
-        query = builder.where("name = ?", "bob").where("age = ?", 23)
+        sql = "select #{query_fields} from table where name = 'bob' and age = ? order by id desc"
+        query = builder.where("name = 'bob'").where("age = ?", 23)
         query.raw_sql.should match ignore_whitespace sql
 
         assembler = query.assembler
         assembler.where
-        assembler.numbered_parameters.should eq ["bob", 23]
+        assembler.numbered_parameters.should eq [23]
       end
     end
 

--- a/spec/granite/query/builder_spec.cr
+++ b/spec/granite/query/builder_spec.cr
@@ -47,4 +47,36 @@ describe Granite::Query::Builder(Model) do
     query = builder.offset(17)
     query.offset.should eq 17
   end
+
+  context "raw SQL builder" do
+    placeholders = {
+      Granite::Query::Builder::DbType::Mysql  => "?",
+      Granite::Query::Builder::DbType::Sqlite => "?",
+      Granite::Query::Builder::DbType::Pg     => "$",
+    }
+
+    it "chains where statements" do
+      placeholder = placeholders[builder.db_type]
+      query = builder.where("name = #{placeholder}", "bob").where("age = #{placeholder}", 23)
+      expected = [{join: :and, stmt: "name = #{placeholder}", value: "bob"}, {join: :and, stmt: "age = #{placeholder}", value: 23}]
+
+      query.where_fields.should eq expected
+    end
+
+    it "chains and statements" do
+      placeholder = placeholders[builder.db_type]
+      query = builder.where("name = #{placeholder}", "bob").and("age = #{placeholder}", 23)
+      expected = [{join: :and, stmt: "name = #{placeholder}", value: "bob"}, {join: :and, stmt: "age = #{placeholder}", value: 23}]
+
+      query.where_fields.should eq expected
+    end
+
+    it "chains or statements" do
+      placeholder = placeholders[builder.db_type]
+      query = builder.where("name = #{placeholder}", "bob").or("age = #{placeholder}", 23)
+      expected = [{join: :and, stmt: "name = #{placeholder}", value: "bob"}, {join: :or, stmt: "age = #{placeholder}", value: 23}]
+
+      query.where_fields.should eq expected
+    end
+  end
 end

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -47,10 +47,10 @@ module Granite::Query::Assembler
           expression = expression.as(NamedTuple(join: Symbol, stmt: String, value: Granite::Columns::Type))
 
           param_token = add_parameter expression[:value]
-          clause = expression[:stmt].sub("?", param_token)
+          clause = expression[:stmt].gsub("?", param_token)
 
           clauses << clause
-        else # standard where query builder
+        else # standard where query
           expression = expression.as(NamedTuple(join: Symbol, field: String, operator: Symbol, value: Granite::Columns::Type))
           add_aggregate_field expression[:field]
 

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -1,5 +1,6 @@
 module Granite::Query::Assembler
   abstract class Base(Model)
+    @placeholder : String = ""
     @where : String?
     @order : String?
     @limit : String?
@@ -48,7 +49,7 @@ module Granite::Query::Assembler
 
           if !expression[:value].nil?
             param_token = add_parameter expression[:value]
-            clause = expression[:stmt].gsub("?", param_token)
+            clause = expression[:stmt].gsub(@placeholder, param_token)
           else
             clause = expression[:stmt]
           end

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -46,8 +46,12 @@ module Granite::Query::Assembler
         if expression[:field]?.nil? # custom SQL
           expression = expression.as(NamedTuple(join: Symbol, stmt: String, value: Granite::Columns::Type))
 
-          param_token = add_parameter expression[:value]
-          clause = expression[:stmt].gsub("?", param_token)
+          if !expression[:value].nil?
+            param_token = add_parameter expression[:value]
+            clause = expression[:stmt].gsub("?", param_token)
+          else
+            clause = expression[:stmt]
+          end
 
           clauses << clause
         else # standard where query

--- a/src/granite/query/assemblers/mysql.cr
+++ b/src/granite/query/assemblers/mysql.cr
@@ -2,6 +2,8 @@
 # This will likely require adapter specific subclassing :[.
 module Granite::Query::Assembler
   class Mysql(Model) < Base(Model)
+    @placeholder = "?"
+
     def add_parameter(value : Granite::Columns::Type) : String
       @numbered_parameters << value
       "?"

--- a/src/granite/query/assemblers/pg.cr
+++ b/src/granite/query/assemblers/pg.cr
@@ -2,6 +2,8 @@
 # This will likely require adapter specific subclassing :[.
 module Granite::Query::Assembler
   class Pg(Model) < Base(Model)
+    @placeholder = "$"
+
     def add_parameter(value : Granite::Columns::Type) : String
       @numbered_parameters << value
       "$#{@numbered_parameters.size}"

--- a/src/granite/query/assemblers/sqlite.cr
+++ b/src/granite/query/assemblers/sqlite.cr
@@ -1,5 +1,7 @@
 module Granite::Query::Assembler
   class Sqlite(Model) < Base(Model)
+    @placeholder = "?"
+
     def add_parameter(value : Granite::Columns::Type) : String
       @numbered_parameters << value
       "?"

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -28,7 +28,8 @@ class Granite::Query::Builder(Model)
   end
 
   getter db_type : DbType
-  getter where_fields = [] of NamedTuple(join: Symbol, field: String, operator: Symbol, value: Granite::Columns::Type)
+  getter where_fields = [] of (NamedTuple(join: Symbol, field: String, operator: Symbol, value: Granite::Columns::Type) |
+                               NamedTuple(join: Symbol, stmt: String, value: Granite::Columns::Type))
   getter order_fields = [] of NamedTuple(field: String, direction: Sort)
   getter group_fields = [] of NamedTuple(field: String)
   getter offset : Int64?
@@ -70,6 +71,10 @@ class Granite::Query::Builder(Model)
     and(field: field.to_s, operator: operator, value: value)
   end
 
+  def where(stmt : String, value : Granite::Columns::Type)
+    and(stmt: stmt, value: value)
+  end
+
   def and(**matches)
     and(matches)
   end
@@ -84,6 +89,12 @@ class Granite::Query::Builder(Model)
 
   def and(field : (Symbol | String), operator : Symbol, value : Granite::Columns::Type)
     @where_fields << {join: :and, field: field.to_s, operator: operator, value: value}
+
+    self
+  end
+
+  def and(stmt : String, value : Granite::Columns::Type)
+    @where_fields << {join: :and, stmt: stmt, value: value}
 
     self
   end

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -117,6 +117,12 @@ class Granite::Query::Builder(Model)
     self
   end
 
+  def or(stmt : String, value : Granite::Columns::Type)
+    @where_fields << {join: :or, stmt: stmt, value: value}
+
+    self
+  end
+
   def order(field : Symbol)
     @order_fields << {field: field.to_s, direction: Sort::Ascending}
 

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -71,7 +71,7 @@ class Granite::Query::Builder(Model)
     and(field: field.to_s, operator: operator, value: value)
   end
 
-  def where(stmt : String, value : Granite::Columns::Type)
+  def where(stmt : String, value : Granite::Columns::Type = nil)
     and(stmt: stmt, value: value)
   end
 
@@ -93,7 +93,7 @@ class Granite::Query::Builder(Model)
     self
   end
 
-  def and(stmt : String, value : Granite::Columns::Type)
+  def and(stmt : String, value : Granite::Columns::Type = nil)
     @where_fields << {join: :and, stmt: stmt, value: value}
 
     self
@@ -117,7 +117,7 @@ class Granite::Query::Builder(Model)
     self
   end
 
-  def or(stmt : String, value : Granite::Columns::Type)
+  def or(stmt : String, value : Granite::Columns::Type = nil)
     @where_fields << {join: :or, stmt: stmt, value: value}
 
     self


### PR DESCRIPTION
This is a first attempt at addressing #402 , and implements support for building simple queries through the use of handwritten SQL like so:
```
users = Users.where("age > ?", 18) # == where(:age, :gt, 18)
```

with the intention of providing a way to support more sophisticated queries, such as
```
users = User.where("LOWER(name) = ?", name)
```
and even database specific features, like checking for membership in an array using Postgres:
```
users = User.where("? = ANY(trusted)", id)
```

The current implementation only allows one argument per query, but it should be rather straightforward to extend this to allow multiple args per query, if that's desired.

A simple spec is included for each DB adapter.

Note: I've opened this PR as a draft because I also intend to include an addition to the docs, but wanted to make this available for review as early as possible.