### PR TITLE
Define @@setter with `class_getter`

### DIFF
--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -43,7 +43,7 @@ abstract class Granite::Base
     include JSON::Serializable
     include YAML::Serializable
 
-    @@select = Container.new(table_name: table_name, fields: fields)
+    class_getter select : Container { Container.new(table_name: table_name, fields: fields) }
 
     # Returns true if this object hasn't been saved yet.
     @[JSON::Field(ignore: true)]

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -40,10 +40,10 @@ abstract class Granite::Base
   extend Select
 
   macro inherited
+    protected class_getter select_container : Container = Container.new(table_name: table_name, fields: fields)
+
     include JSON::Serializable
     include YAML::Serializable
-
-    class_getter select : Container { Container.new(table_name: table_name, fields: fields) }
 
     # Returns true if this object hasn't been saved yet.
     @[JSON::Field(ignore: true)]

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -8,14 +8,10 @@ module Granite::Select
   end
 
   macro select_statement(text)
-    self.select.custom = {{text.strip}}
+    @@select_container.custom = {{text.strip}}
 
-    def self.select
-      self.select.custom
+    def self.select : String?
+      self.select_container.custom
     end
-  end
-
-  def select_container : Container
-    self.select
   end
 end

--- a/src/granite/select.cr
+++ b/src/granite/select.cr
@@ -8,14 +8,14 @@ module Granite::Select
   end
 
   macro select_statement(text)
-    @@select.custom = {{text.strip}}
+    self.select.custom = {{text.strip}}
 
     def self.select
-      @@select.custom
+      self.select.custom
     end
   end
 
   def select_container : Container
-    @@select
+    self.select
   end
 end


### PR DESCRIPTION
Reboot of https://github.com/amberframework/granite/pull/345.  Was getting:

```
Showing last frame. Use --error-trace for full trace.

In lib/granite/src/granite/select.cr:19:5

19 | @@select
^
Error: can't infer the type of class variable '@@select' of Granite::Base.class

The type of a class variable, if not declared explicitly with
`@@select : Type`, is inferred from assignments to it across
the whole program.

...

Other assignments have no effect on its type.

can't infer the type of class variable '@@select' of Granite::Base.class
```

When working on some Athena stuff.