### PR TITLE
Added a way to disable validation on save method

### DIFF
--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -15,6 +15,20 @@ describe "#save" do
     parent.persisted?.should be_false
   end
 
+  it "create an invalid object with validation disabled" do
+    parent = Parent.new
+    parent.name = ""
+    parent.save(validate: false)
+    parent.persisted?.should be_true
+  end
+
+  it "does not create an invalid object with validation explicitly enabled" do
+    parent = Parent.new
+    parent.name = ""
+    parent.save(validate: true)
+    parent.persisted?.should be_false
+  end
+
   it "does not save a model with type conversion errors" do
     model = Comment.new(articleid: "foo")
     model.errors.size.should eq 1
@@ -42,6 +56,31 @@ describe "#save" do
     parent.save
     parent.name = ""
     parent.save
+    parent = Parent.find! parent.id
+    parent.name.should eq "Test Parent"
+  end
+
+  it "update an invalid object with validation disabled" do
+    Parent.clear
+    parent = Parent.new
+    parent.name = "Test Parent"
+    parent.save
+    parent.name = ""
+    parent.save(validate: false)
+
+    parents = Parent.all
+    parents.size.should eq 1
+
+    found = Parent.first!
+    found.name.should eq parent.name
+  end
+
+  it "does not update an invalid object with validation explicitly enabled" do
+    parent = Parent.new
+    parent.name = "Test Parent"
+    parent.save
+    parent.name = ""
+    parent.save(validate: true)
     parent = Parent.find! parent.id
     parent.name.should eq "Test Parent"
   end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -169,12 +169,12 @@ module Granite::Transactions
   # The save method will check to see if the primary exists yet. If it does it
   # will call the update method, otherwise it will call the create method.
   # This will update the timestamps appropriately.
-  def save
+  def save(**args)
     {% begin %}
     {% primary_key = @type.instance_vars.find { |ivar| (ann = ivar.annotation(Granite::Column)) && ann[:primary] } %}
     {% raise raise "A primary key must be defined for #{@type.name}." unless primary_key %}
     {% ann = primary_key.annotation(Granite::Column) %}
-    return false unless valid?
+    return false if args.fetch("validate", true) && !valid?
 
     begin
       __before_save
@@ -199,8 +199,8 @@ module Granite::Transactions
   {% end %}
   end
 
-  def save!
-    save || raise Granite::RecordNotSaved.new(self.class.name, self)
+  def save!(**args)
+    save(**args) || raise Granite::RecordNotSaved.new(self.class.name, self)
   end
 
   def update(**args)

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -169,12 +169,12 @@ module Granite::Transactions
   # The save method will check to see if the primary exists yet. If it does it
   # will call the update method, otherwise it will call the create method.
   # This will update the timestamps appropriately.
-  def save(**args)
+  def save(*, validate : Bool = true)
     {% begin %}
     {% primary_key = @type.instance_vars.find { |ivar| (ann = ivar.annotation(Granite::Column)) && ann[:primary] } %}
     {% raise raise "A primary key must be defined for #{@type.name}." unless primary_key %}
     {% ann = primary_key.annotation(Granite::Column) %}
-    return false if args.fetch("validate", true) && !valid?
+    return false if validate && !valid?
 
     begin
       __before_save
@@ -199,8 +199,8 @@ module Granite::Transactions
   {% end %}
   end
 
-  def save!(**args)
-    save(**args) || raise Granite::RecordNotSaved.new(self.class.name, self)
+  def save!(*, validate : Bool = true)
+    save(validate: validate) || raise Granite::RecordNotSaved.new(self.class.name, self)
   end
 
   def update(**args)


### PR DESCRIPTION
This PR add an named argument to `#save` method which allow to disable model validation, example:

```crystal
class Example < Granite::Base
  ...
  column name : String?
  
  validate :name, "Name cannot be blank" do |parent|
    !parent.name.to_s.blank?
  end
  ...
end

new_instance = Example.new
new_instance.name = ""
new_instance.save(validate: false)
new_instance.persisted? #=> true

another_instance = Example.new
another_instance.name = ""
another_instance.save(validate: true)
another_instance.persisted? #=> false
```

No breaking changes and works as well with `#save!`