### PR TITLE
Documentation fixes for the following errors

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -111,7 +111,7 @@ posts = Post.all("JOIN comments c ON c.post_id = post.id
 The `select_statement` macro allows you to customize the entire query, including the SELECT portion.  This shouldn't be necessary in most cases, but allows you to craft more complex (i.e. cross-table) queries if needed:
 
 ```crystal
-class CustomView < Granite:Base
+class CustomView < Granite::Base
   connection pg
 
   column id : Int64, primary: true

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -64,7 +64,7 @@ CREATE TABLE coaches (
   updated_at TIMESTAMP
 );
 
-CREATE INDEX 'team_id_idx' ON coaches (team_id);
+CREATE INDEX team_id_idx ON coaches (team_id);
 ```
 
 Foreign key is inferred from the class name of the Model which uses `has_one`. In above case `team_id` is assumed to be present in `coaches` table. In case its different you can specify one like this:
@@ -181,7 +181,7 @@ CREATE TABLE posts (
   updated_at TIMESTAMP
 );
 
-CREATE INDEX 'user_id_idx' ON posts (user_id);
+CREATE INDEX user_id_idx ON posts (user_id);
 ```
 
 ## Many to Many
@@ -230,8 +230,8 @@ CREATE TABLE participants (
   updated_at TIMESTAMP
 );
 
-CREATE INDEX 'user_id_idx' ON TABLE participants (user_id);
-CREATE INDEX 'room_id_idx' ON TABLE participants (room_id);
+CREATE INDEX user_id_idx ON TABLE participants (user_id);
+CREATE INDEX room_id_idx ON TABLE participants (room_id);
 ```
 
 ## has_many through:


### PR DESCRIPTION
CustomView Example,

```
 1 | class CustomView < Granite:Base
                         ^
Error: Granite is not a class, it's a module
```

Create Index was failing silently when used with `amber db migrate`

```
=# CREATE INDEX 'team_id_idx' ON coaches (team_id);
ERROR:  syntax error at or near "'team_id_idx'"
LINE 1: CREATE INDEX 'team_id_idx' ON coaches (team_id);
                     ^
```

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>