### PR TITLE
Migrator: create columns with NOT NULL as appropriate

### DIFF
--- a/spec/granite/migrator/migrator_spec.cr
+++ b/spec/granite/migrator/migrator_spec.cr
@@ -45,6 +45,13 @@ describe Granite::Migrator do
           "uuid" UUID PRIMARY KEY) ;\n
           SQL
 
+        Character.migrator.create_sql.should eq <<-SQL
+          CREATE TABLE "characters"(
+          "character_id" SERIAL PRIMARY KEY,
+          "name" TEXT NOT NULL
+          ) ;\n
+          SQL
+
         # Also check Array types for pg
         ArrayModel.migrator.create_sql.should eq <<-SQL
           CREATE TABLE "array_model"(
@@ -91,6 +98,13 @@ describe Granite::Migrator do
           ) ;\n
           SQL
 
+        Character.migrator.create_sql.should eq <<-SQL
+          CREATE TABLE `characters`(
+          `character_id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+          `name` VARCHAR(255) NOT NULL
+          ) ;\n
+          SQL
+
         UUIDModel.migrator.create_sql.should eq <<-SQL
           CREATE TABLE `uuids`(
           `uuid` CHAR(36) PRIMARY KEY) ;\n
@@ -119,6 +133,13 @@ describe Granite::Migrator do
           CREATE TABLE "kvs"(
           "k" VARCHAR(255) PRIMARY KEY,
           "v" VARCHAR(255)
+          ) ;\n
+          SQL
+
+        Character.migrator.create_sql.should eq <<-SQL
+          CREATE TABLE "characters"(
+          "character_id" INTEGER NOT NULL PRIMARY KEY,
+          "name" VARCHAR(255) NOT NULL
           ) ;\n
           SQL
 

--- a/src/granite/migrator.cr
+++ b/src/granite/migrator.cr
@@ -72,8 +72,10 @@ module Granite::Migrator
               "{{ann[:column_type].id}}"
             {% elsif ivar.name.id == "created_at" || ivar.name.id == "updated_at" %}
               resolve.call("{{ivar.name}}")
-            {% else %}
+            {% elsif ann[:nilable] %}
               resolve.call("{{ivar.type.union_types.find { |t| t != Nil }.id}}")
+            {% else %}
+              resolve.call("{{ivar.type.union_types.find { |t| t != Nil }.id}}") + " NOT NULL"
             {% end %}
           s.puts "#{k} #{v}"
         {% end %}


### PR DESCRIPTION
The built-in Model.migrator.create_sql will create columns
with NOT NULL unless the types are in fact nullable.