### PR TITLE
Drop argument type restrictions in FakeConnection

### DIFF
--- a/spec/mocks/db_mock.cr
+++ b/spec/mocks/db_mock.cr
@@ -30,11 +30,11 @@ class FakeConnection < DB::Connection
     @prepared_statements = false
   end
 
-  def build_unprepared_statement(query : String) : FakeStatement
+  def build_unprepared_statement(query) : FakeStatement
     FakeStatement.new self
   end
 
-  def build_prepared_statement(query : String) : FakeStatement
+  def build_prepared_statement(query) : FakeStatement
     FakeStatement.new self
   end
 end


### PR DESCRIPTION
crystal-db does not include a type restriction. Since 1.0.0-dev is more strict with abstract methods this change is required to make the FakeConnection honor the current DB::Connection API

Maybe crystal-db should restrict the query to String since the DB::Statement now has a `@command : String`. That can come later in future releases while being backward compatible.

Ref: https://github.com/crystal-lang/crystal/pull/9634