### PR TITLE
Add primary field to belongs_to relationships

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -63,6 +63,17 @@ class Site < Granite::Base
 end
 ```
 
+`belongs_to` associations can also be used as a primary key in much the same way.
+
+```crystal
+class ChatSettings < Granite::Base
+  connection mysql
+
+  # chat_id would be the primary key
+  belongs_to chat : Chat, primary: true
+end
+```
+
 ### Custom
 
 The name and type of the primary key can also be changed from the recommended `id : Int64`.

--- a/spec/granite/associations/belongs_to_spec.cr
+++ b/spec/granite/associations/belongs_to_spec.cr
@@ -112,4 +112,16 @@ describe "belongs_to" do
 
     courier.service!.owner_id.should eq 123_321
   end
+
+  it "allows a belongs_to association to be a primary key" do
+    chat = Chat.new
+    chat.name = "My Awesome Chat"
+    chat.save
+
+    settings = ChatSettings.new
+    settings.chat = chat
+    settings.save
+
+    settings.chat_id!.should eq chat.id
+  end
 end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -8,6 +8,26 @@ end
 {% begin %}
   {% adapter_literal = env("CURRENT_ADAPTER").id %}
 
+  class Chat < Granite::Base
+    connection {{ adapter_literal }}
+    table chats
+
+    column id : Int64, primary: true
+
+    column name : String
+
+    has_one settings : ChatSettings, foreign_key: :chat_id
+  end
+
+  class ChatSettings < Granite::Base
+    connection {{ adapter_literal }}
+    table chat_settings
+
+    belongs_to chat : Chat, primary: true
+
+    column flood_limit : Int32
+  end
+
   class Parent < Granite::Base
     connection {{ adapter_literal }}
     table parents

--- a/src/granite/associations.cr
+++ b/src/granite/associations.cr
@@ -10,10 +10,10 @@ module Granite::Associations
 
     {% if options[:foreign_key] && options[:foreign_key].is_a? TypeDeclaration %}
       {% foreign_key = options[:foreign_key].var %}
-      column {{options[:foreign_key]}}{% if options[:primary] %}, primary {{options[:primary]}}{% end %}
+      column {{options[:foreign_key]}}{% if options[:primary] %}, primary: {{options[:primary]}}{% end %}
     {% else %}
       {% foreign_key = method_name + "_id" %}
-      column {{foreign_key}} : Int64?{% if options[:primary] %}, primary {{options[:primary]}}{% end %}
+      column {{foreign_key}} : Int64?{% if options[:primary] %}, primary: {{options[:primary]}}{% end %}
     {% end %}
     {% primary_key = options[:primary_key] || "id" %}
 

--- a/src/granite/associations.cr
+++ b/src/granite/associations.cr
@@ -10,10 +10,10 @@ module Granite::Associations
 
     {% if options[:foreign_key] && options[:foreign_key].is_a? TypeDeclaration %}
       {% foreign_key = options[:foreign_key].var %}
-      column {{options[:foreign_key]}}
+      column {{options[:foreign_key]}}{% if options[:primary] %}, primary {{options[:primary]}}{% end %}
     {% else %}
       {% foreign_key = method_name + "_id" %}
-      column {{foreign_key}} : Int64?
+      column {{foreign_key}} : Int64?{% if options[:primary] %}, primary {{options[:primary]}}{% end %}
     {% end %}
     {% primary_key = options[:primary_key] || "id" %}
 


### PR DESCRIPTION
Really simple change that allows the creation of `belongs_to` relationships in which the created `column` is the primary key for the table.