### PR TITLE
Add type restrictions to methods in Adapter::Base

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -33,7 +33,7 @@ abstract class Granite::Adapter::Base
   end
 
   # remove all rows from a table and reset the counter on the id.
-  abstract def clear(table_name)
+  abstract def clear(table_name : String)
 
   # select performs a query against a table.  The query object contains table_name,
   # fields (configured using the sql_mapping directive in your model), and an optional
@@ -79,16 +79,16 @@ abstract class Granite::Adapter::Base
   end
 
   # This will insert a row in the database and return the id generated.
-  abstract def insert(table_name, fields, params, lastval) : Int64
+  abstract def insert(table_name : String, fields, params, lastval) : Int64
 
   # This will insert an array of models as one insert statement
   abstract def import(table_name : String, primary_name : String, auto : Bool, fields, model_array, **options)
 
   # This will update a row in the database.
-  abstract def update(table_name, primary_name, fields, params)
+  abstract def update(table_name : String, primary_name : String, fields, params)
 
   # This will delete a row from the database.
-  abstract def delete(table_name, primary_name, value)
+  abstract def delete(table_name : String, primary_name : String, value)
 
   module Schema
     TYPES = {


### PR DESCRIPTION
Currently there are errors in adapters when compiling against Crystal built from master:

* `Error: abstract def Granite::Adapter::Base#clear(table_name) must be implemented by Granite::Adapter::Pg`
* `Error: abstract def Granite::Adapter::Base#insert(table_name, fields, params, lastval) must be implemented by Granite::Adapter::Pg`
* `Error: abstract def Granite::Adapter::Base#update(table_name, primary_name, fields, params) must be implemented by Granite::Adapter::Pg`
* `Error: abstract def Granite::Adapter::Base#delete(table_name, primary_name, value) must be implemented by Granite::Adapter::Pg`

For other adapters there are the same errors.

This PR fixes the problem. Because of subclasses already define all these methods with type restrictions, there should not be breaking changes.

Tested against:

```
Crystal 0.36.0-dev [7e0fdb0] (2021-01-18)

LLVM: 11.0.0
Default target: x86_64-unknown-linux-musl
```
(crystal-lang/crystal@7e0fdb0a)