### PR TITLE
Updates for Crystal 0.36 and crystal-db 0.10

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,20 +13,20 @@ license: MIT
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.9.0
+    version: ~> 0.10.0
 
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.11.1
+    version: ~> 0.12.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.16.0
+    version: ~> 0.17.0
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.21.1
+    version: ~> 0.23.0
 
   ameba:
     github: crystal-ameba/ameba

--- a/spec/mocks/db_mock.cr
+++ b/spec/mocks/db_mock.cr
@@ -31,11 +31,11 @@ class FakeConnection < DB::Connection
   end
 
   def build_unprepared_statement(query) : FakeStatement
-    FakeStatement.new self
+    FakeStatement.new self, query
   end
 
   def build_prepared_statement(query) : FakeStatement
-    FakeStatement.new self
+    FakeStatement.new self, query
   end
 end
 
@@ -55,7 +55,7 @@ class FieldEmitter < DB::ResultSet
   @values = [] of EmitterType
 
   def initialize
-    @statement = FakeStatement.new FakeConnection.new
+    @statement = FakeStatement.new FakeConnection.new, ""
   end
 
   def _set_values(values : Array(EmitterType))

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -79,16 +79,16 @@ abstract class Granite::Adapter::Base
   end
 
   # This will insert a row in the database and return the id generated.
-  abstract def insert(table_name, fields, params, lastval) : Int64
+  abstract def insert(table_name : String, fields, params, lastval) : Int64
 
   # This will insert an array of models as one insert statement
   abstract def import(table_name : String, primary_name : String, auto : Bool, fields, model_array, **options)
 
   # This will update a row in the database.
-  abstract def update(table_name, primary_name, fields, params)
+  abstract def update(table_name : String, primary_name : String, fields, params)
 
   # This will delete a row from the database.
-  abstract def delete(table_name, primary_name, value)
+  abstract def delete(table_name : String, primary_name : String, value)
 
   module Schema
     TYPES = {

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -33,7 +33,7 @@ abstract class Granite::Adapter::Base
   end
 
   # remove all rows from a table and reset the counter on the id.
-  abstract def clear(table_name)
+  abstract def clear(table_name : String)
 
   # select performs a query against a table.  The query object contains table_name,
   # fields (configured using the sql_mapping directive in your model), and an optional


### PR DESCRIPTION
The following changes are needed for crystal 0.36, yet they should be compatible with 0.35.

crystal-db 0.10 is has been out for a while and has a couple of breaking changes. If they are not wanted feel free to close this PR and reuse it partially.

To update to crystal-db the required versions of the drivers needed to be updated also. crystal-mysql and crystal-sqlite3 will likely have a minor version update soon due to new features.