### PR TITLE
Add context to RecordNotSaved/RecordNotDestroyed error messages

### DIFF
--- a/spec/granite/exceptions/record_invalid_spec.cr
+++ b/spec/granite/exceptions/record_invalid_spec.cr
@@ -8,7 +8,7 @@ describe Granite::RecordNotSaved do
     Granite::RecordNotSaved
       .new(Parent.name, parent)
       .message
-      .should eq("Could not process Parent")
+      .should eq("Could not process Parent: Name cannot be blank")
   end
 
   it "should have a model" do

--- a/spec/granite/exceptions/record_not_destroyed_spec.cr
+++ b/spec/granite/exceptions/record_not_destroyed_spec.cr
@@ -8,7 +8,7 @@ describe Granite::RecordNotDestroyed do
     Granite::RecordNotDestroyed
       .new(Parent.name, parent)
       .message
-      .should eq("Could not destroy Parent")
+      .should eq("Could not destroy Parent: Name cannot be blank")
   end
 
   it "should have a model" do

--- a/src/granite/exceptions.cr
+++ b/src/granite/exceptions.cr
@@ -2,20 +2,16 @@ module Granite
   class RecordNotSaved < ::Exception
     getter model : Granite::Base
 
-    def initialize(class_name : String, model : Granite::Base)
-      super("Could not process #{class_name}")
-
-      @model = model
+    def initialize(class_name : String, @model : Granite::Base)
+      super("Could not process #{class_name}: #{model.errors.first.message}")
     end
   end
 
   class RecordNotDestroyed < ::Exception
     getter model : Granite::Base
 
-    def initialize(class_name : String, model : Granite::Base)
-      super("Could not destroy #{class_name}")
-
-      @model = model
+    def initialize(class_name : String, @model : Granite::Base)
+      super("Could not destroy #{class_name}: #{model.errors.first.message}")
     end
   end
 end


### PR DESCRIPTION
Hello,

I struggled to display error messages from Granite when testing my code. The `RecordNotSaved` and `RecordNotDestroyed` messages are too generic and do not provide any clue about what is going on when an error is triggered when calling `save!` or `destroy!`.

We could, indeed, call `save` instead of `save!` and collect those error messages. But it would be cumbersome and need to add boilerplate everywhere. IMHO, it is usually simpler (and preferred) to manage exceptions.

So, I've added the message of the first error in the model to ease the feedback loop and have some understandings on the error directly instead of having to add code around to know what is the real issue.

Please let me know if you disagree with this and if you would see a better implementation.

Cheers!

