### PR TITLE
Fix command to create a migration to `scaffold`

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -49,7 +49,7 @@ We should now be able to run micrate commands.
 Let's create a `posts` table in our database.
 
 ```sh
-$ bin/micrate create create_posts
+$ bin/micrate scaffold create_posts
 ```
 
 This will create a file under `db/migrations`. Let's open it and define our posts schema.


### PR DESCRIPTION
As of at least Micrate 0.11.0, `bin/micrate create` doesn't create a migration file, it creates the database. `scaffold` is the command to create a migration file. This PR corrects this in the migration docs.

```bash
$ bin/micrate help

*snip*
Commands:
    create     Create the database (permissions required)
*snip*
    scaffold   Create the scaffolding for a new migration
```