### PR TITLE
Add a check to ensure created_at and updated_at are Time

### DIFF
--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -78,13 +78,13 @@ module Granite::Transactions
   end
 
   def set_timestamps(*, to time = Time.local(Granite.settings.default_timezone), mode = :create)
-    {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) }.map(&.name.stringify).includes? "created_at" %}
+    {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) && ivar.type == Time? }.map(&.name.stringify).includes? "created_at" %}
       if mode == :create
         @created_at = time.at_beginning_of_second
       end
     {% end %}
 
-    {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) }.map(&.name.stringify).includes? "updated_at" %}
+    {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) && ivar.type == Time? }.map(&.name.stringify).includes? "updated_at" %}
       @updated_at = time.at_beginning_of_second
     {% end %}
   end


### PR DESCRIPTION
If a column is named `created_at` or `updated_at` is not a type `Time?`, then the following occurs:

```There was a problem expanding macro 'macro_4801706624'

Code in lib/granite/src/granite/transactions.cr:82:5

 82 | {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) }.map(&.name.stringify).includes? "created_at" %}
      ^
Called macro defined in lib/granite/src/granite/transactions.cr:82:5

 82 | {% if @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) }.map(&.name.stringify).includes? "created_at" %}

Which expanded to:

 > 1 |
 > 2 |       if mode == :create
 > 3 |         @created_at = time.at_beginning_of_second
                                  ^---------------------
```

this simply adds a type check.