### PR TITLE
fix build_find_by_clause for bool values

### DIFF
--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -135,7 +135,7 @@ module Granite::Querying
     criteria_hash = criteria.dup
 
     clauses = keys.map do |name|
-      if criteria_hash[name]
+      if criteria_hash.has_key?(name) && !criteria_hash[name].nil?
         matcher = "= ?"
       else
         matcher = "IS NULL"


### PR DESCRIPTION
Checking for existing records where column type is `bool` if you search with criteria where the column is `false` it will query it as `is NULL` instead of `is false`.

```
criteria: {scryfall_uuid: UUID(9c198ffd-50c8-46ae-a4bd-75c9d39f40de),
 inventory_uuid: UUID(9ae21165-09d8-4a33-88ec-5dbf0b4b8f4a),
 foil: false,
 etched: false}
2021-08-31T20:04:53.403044Z  DEBUG - db: Executing query -- query: "SELECT EXISTS(SELECT 1 FROM `card_record` WHERE `card_record`.`scryfall_uuid` = ? AND `card_record`.`inventory_uuid` = ? AND `card_record`.`foil` IS NULL AND `card_record`.`etched` IS NULL)", args: ["9c198ffd-50c8-46ae-a4bd-75c9d39f40de", "9ae21165-09d8-4a33-88ec-5dbf0b4b8f4a"]
does not exist
```

after fix:

```
criteria: {scryfall_uuid: UUID(9c198ffd-50c8-46ae-a4bd-75c9d39f40de),
 inventory_uuid: UUID(9ae21165-09d8-4a33-88ec-5dbf0b4b8f4a),
 foil: false,
 etched: false}
2021-08-31T20:06:33.623789Z  DEBUG - db: Executing query -- query: "SELECT EXISTS(SELECT 1 FROM `card_record` WHERE `card_record`.`scryfall_uuid` = ? AND `card_record`.`inventory_uuid` = ? AND `card_record`.`foil` = ? AND `card_record`.`etched` = ?)", args: ["9c198ffd-50c8-46ae-a4bd-75c9d39f40de", "9ae21165-09d8-4a33-88ec-5dbf0b4b8f4a", false, false]
Exists Path of Ancestry (9c198ffd-50c8-46ae-a4bd-75c9d39f40de)
```