### PR TITLE
Fix code block in `models.md`

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -54,6 +54,7 @@ end
 Each model is required to have a primary key defined.  Use the `column` macro with the `primary: true` option to denote the primary key. 
 
 > **NOTE:** Composite primary keys are not yet supported.
+
 ```crystal
 class Site < Granite::Base
   connection mysql


### PR DESCRIPTION
This missing newline after the note/quote is breaking the layout on GitBook. This PR adds an extra newline so it also looks good on GitBook.


| Before | After |
| --- | --- |
| ![Screenshot 2021-10-05 at 20 30 05](https://user-images.githubusercontent.com/6411752/136081921-436aa3e5-96d7-4aa6-b3b0-ecab114bb8fa.png) |  ![Screenshot 2021-10-05 at 20 30 19](https://user-images.githubusercontent.com/6411752/136081904-18851deb-6a71-4832-87cd-8a2540bc16e4.png) |


