### PR TITLE
Fixing a timestamp issue to support Crystal 1.0.0+

### DIFF
--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -262,7 +262,6 @@ module Granite::Transactions
       end
     {% end %}
     set_timestamps mode: :update
-    #@updated_at = Time.local(Granite.settings.default_timezone).at_beginning_of_second
     save
   end
 end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -261,7 +261,8 @@ module Granite::Transactions
         end
       end
     {% end %}
-    @updated_at = Time.local(Granite.settings.default_timezone).at_beginning_of_second
+    set_timestamps mode: :update
+    #@updated_at = Time.local(Granite.settings.default_timezone).at_beginning_of_second
     save
   end
 end


### PR DESCRIPTION
As @Blacksmoke16 suggested [here](https://github.com/amberframework/granite/pull/464#issuecomment-1126942364), I changed the `#touch` method to use `#set_timestamps` instead of trying to directly update the `@updated_at` attribute.

I couldn't get the test suite to run locally, however, I made a test project that duplicated the issue described here and on the Amber repo and changed the info for Granite to point to my forked version with the change here and amber successfully compiled and displayed the welcome page.

I think this is a success!