### PR TITLE
Read JSON::Any Columns as `.to_json`'d String

### DIFF
--- a/src/granite/columns.cr
+++ b/src/granite/columns.cr
@@ -149,7 +149,12 @@ module Granite::Columns
     {% begin %}
       case attribute_name.to_s
       {% for column in @type.instance_vars.select { |ivar| ivar.annotation(Granite::Column) } %}
-        when "{{ column.name }}" then @{{ column.name.id }}
+        {% if column.type.union? && column.type.union_types.includes?(JSON::Any) %}
+          {% puts "registering #{column} with a .to_json" %}
+          when "{{ column.name }}" then @{{ column.name.id }}.to_json
+        {% else %}
+          when "{{ column.name }}" then @{{ column.name.id }}
+        {% end %}
       {% end %}
       else
         raise "Cannot read attribute #{attribute_name}, invalid attribute"


### PR DESCRIPTION
Greetings 👋 

Submitting this small PR as I recently ran into an issue when using `import` for a model. If I created the model one-off and used `.new` (add attribute values) then `.save`, the model would save just fine. If I instead set up a bunch of models then used `.import`, I'd get an error that stemmed down to this issue. 

The short of it is that each adapter's `import` ([pg's here](https://github.com/amberframework/granite/blob/3f1f236d8c4814ee83c81d9cf068ec9c8d5065ef/src/adapter/pg.cr#L87)) calls `read_attribute` under the hood and passes the then-read value along to the query builder but does so with its native type. If you ask a model for the value of a `JSON::Any`-typed column, you'll get a `JSON::Any` typed value. The query builder doesn't like that type though and will error.

This PR injects a `.to_json` in the process for any column whose type includes `JSON::Any`. This does indeed convert the value to a string and makes the query builder happy, but this PR may well be a proof of concept. There is definitely a better way of doing this, and this may overall be a stop-gap where correctly wiring up the Granite Converter(s) could be the right choice. Submitting this to explain my story, give some context, and hopefully inspire a better path forward!

Cheers!