### PR TITLE
add #next_column_index to db mocker

### DIFF
--- a/spec/mocks/db_mock.cr
+++ b/spec/mocks/db_mock.cr
@@ -88,4 +88,8 @@ class FieldEmitter < DB::ResultSet
   def column_name(index : Int32) : String
     "Column #{index}"
   end
+
+  def next_column_index : Int32
+    @field_position
+  end
 end


### PR DESCRIPTION
This is required by changes made in crystal-db v0.11.0