### PR TITLE
Feature: Read replica support

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
 MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
+MYSQL_REPLICA_URL=mysql://granite:password@localhost:3306/granite_replica_db
 SQLITE_DATABASE_URL=sqlite3:./granite.db
 SQLITE_REPLICA_URL=sqlite3:./granite_replica.db
 CURRENT_ADAPTER=pg

--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
 MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
 SQLITE_DATABASE_URL=sqlite3:./granite.db
+SQLITE_REPLICA_URL=sqlite3:./granite_replica.db
 CURRENT_ADAPTER=pg
 PG_VERSION=15.2
 MYSQL_VERSION=5.7

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ shard.lock
 
 # Ignore bin because they will be build with shards install
 bin
-.env_kalinon
+.env

--- a/export.sh
+++ b/export.sh
@@ -1,0 +1,9 @@
+export PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
+export MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
+export SQLITE_DATABASE_URL=sqlite3:./granite.db
+export SQLITE_REPLICA_URL=sqlite3:./granite_replica.db
+export PG_VERSION=15.2
+export MYSQL_VERSION=5.7
+export SQLITE_VERSION=3110000
+export SQLITE_VERSION_YEAR=2016
+export CURRENT_ADAPTER=sqlite

--- a/export.sh
+++ b/export.sh
@@ -1,4 +1,5 @@
 export PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
+export PG_REPLICA_URL=postgres://granite:password@localhost:5432/granite__replica_db
 export MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
 export MYSQL_REPLICA_URL=mysql://granite:password@localhost:3306/granite_replica_db
 export SQLITE_DATABASE_URL=sqlite3:./granite.db

--- a/export.sh
+++ b/export.sh
@@ -1,5 +1,6 @@
 export PG_DATABASE_URL=postgres://granite:password@localhost:5432/granite_db
 export MYSQL_DATABASE_URL=mysql://granite:password@localhost:3306/granite_db
+export MYSQL_REPLICA_URL=mysql://granite:password@localhost:3306/granite_replica_db
 export SQLITE_DATABASE_URL=sqlite3:./granite.db
 export SQLITE_REPLICA_URL=sqlite3:./granite_replica.db
 export PG_VERSION=15.2

--- a/spec/adapter/adapters_spec.cr
+++ b/spec/adapter/adapters_spec.cr
@@ -16,17 +16,17 @@ describe Granite::Connections do
       Granite::Connections.registered_connections.size.should eq 3
 
       if connection = Granite::Connections["mysql"]
-        connection.url.should eq ENV["MYSQL_DATABASE_URL"]
+        connection[:writer].url.should eq ENV["MYSQL_DATABASE_URL"]
       else
         connection.should_not be_falsey
       end
       if connection = Granite::Connections["pg"]
-        connection.url.should eq ENV["PG_DATABASE_URL"]
+        connection[:writer].url.should eq ENV["PG_DATABASE_URL"]
       else
         connection.should_not be_falsey
       end
       if connection = Granite::Connections["sqlite"]
-        connection.url.should eq ENV["SQLITE_DATABASE_URL"]
+        connection[:writer].url.should eq ENV["SQLITE_DATABASE_URL"]
       else
         connection.should_not be_falsey
       end

--- a/spec/adapter/adapters_spec.cr
+++ b/spec/adapter/adapters_spec.cr
@@ -13,7 +13,7 @@ end
 describe Granite::Connections do
   describe "registration" do
     it "should allow connections to be be saved and looked up" do
-      Granite::Connections.registered_connections.size.should eq 5
+      Granite::Connections.registered_connections.size.should eq 6
 
       if connection = Granite::Connections["mysql"]
         connection[:writer].url.should eq ENV["MYSQL_DATABASE_URL"]

--- a/spec/adapter/adapters_spec.cr
+++ b/spec/adapter/adapters_spec.cr
@@ -13,7 +13,7 @@ end
 describe Granite::Connections do
   describe "registration" do
     it "should allow connections to be be saved and looked up" do
-      Granite::Connections.registered_connections.size.should eq 4
+      Granite::Connections.registered_connections.size.should eq 5
 
       if connection = Granite::Connections["mysql"]
         connection[:writer].url.should eq ENV["MYSQL_DATABASE_URL"]
@@ -30,7 +30,7 @@ describe Granite::Connections do
       else
         connection.should_not be_falsey
       end
-      if connection = Granite::Connections["sqlite_replica"]
+      if connection = Granite::Connections["sqlite_with_replica"]
         connection[:writer].url.should eq ENV["SQLITE_DATABASE_URL"]
         connection[:reader].url.should eq ENV["SQLITE_REPLICA_URL"]
       else

--- a/spec/adapter/adapters_spec.cr
+++ b/spec/adapter/adapters_spec.cr
@@ -13,7 +13,7 @@ end
 describe Granite::Connections do
   describe "registration" do
     it "should allow connections to be be saved and looked up" do
-      Granite::Connections.registered_connections.size.should eq 3
+      Granite::Connections.registered_connections.size.should eq 4
 
       if connection = Granite::Connections["mysql"]
         connection[:writer].url.should eq ENV["MYSQL_DATABASE_URL"]
@@ -27,6 +27,12 @@ describe Granite::Connections do
       end
       if connection = Granite::Connections["sqlite"]
         connection[:writer].url.should eq ENV["SQLITE_DATABASE_URL"]
+      else
+        connection.should_not be_falsey
+      end
+      if connection = Granite::Connections["sqlite_replica"]
+        connection[:writer].url.should eq ENV["SQLITE_DATABASE_URL"]
+        connection[:reader].url.should eq ENV["SQLITE_REPLICA_URL"]
       else
         connection.should_not be_falsey
       end

--- a/spec/granite/connection_management_spec.cr
+++ b/spec/granite/connection_management_spec.cr
@@ -14,4 +14,13 @@ describe "Granite::Base track time since last write" do
       raise "ERROR!!!!!"
     end
   end
+
+  it "should switch to reader db connection after connection_switch_wait_period after write operation" do
+    ReplicatedChat.new(content: "hello world!").save!
+    ReplicatedChat.connection_switch_wait_period = 250
+    sleep ReplicatedChat.connection_switch_wait_period.milliseconds
+    current_url = ReplicatedChat.adapter.url
+    reader_url = Granite::Connections[ENV["CURRENT_ADAPTER"] + "_with_replica"].not_nil![:reader].url
+    current_url.should eq reader_url
+  end
 end

--- a/spec/granite/connection_management_spec.cr
+++ b/spec/granite/connection_management_spec.cr
@@ -1,24 +1,10 @@
 require "spec"
 
 describe "Granite::Base track time since last write" do
-  it "should ensure that time since last write to model is saved" do
-    # This is a good way to test last write time
-    # It is unlikely that the test suite takes more than an hour to run
-    (ReplicatedChat.time_since_last_write < 1.hours).should be_true
-
-    # Update the time since last write. Ensure it updated to the time within the currnet second
-    ReplicatedChat.update_last_write_time
-
-    # Time since last write should be less than a second since we just updated it (see line above)
-    unless (ReplicatedChat.time_since_last_write < 1.second)
-      raise "ERROR!!!!!"
-    end
-  end
-
   it "should switch to reader db connection after connection_switch_wait_period after write operation" do
-    ReplicatedChat.new(content: "hello world!").save!
     ReplicatedChat.connection_switch_wait_period = 250
-    sleep ReplicatedChat.connection_switch_wait_period.milliseconds
+    ReplicatedChat.new(content: "hello world!").save!
+    sleep 500.milliseconds
     current_url = ReplicatedChat.adapter.url
     reader_url = Granite::Connections[ENV["CURRENT_ADAPTER"] + "_with_replica"].not_nil![:reader].url
     current_url.should eq reader_url

--- a/spec/granite/connection_switching_spec.cr
+++ b/spec/granite/connection_switching_spec.cr
@@ -4,13 +4,13 @@ describe "Granite::Base track time since last write" do
   it "should ensure that time since last write to model is saved" do
     # This is a good way to test last write time
     # It is unlikely that the test suite takes more than an hour to run
-    (Chat.time_since_last_write < 1.hours).should be_true
+    (ReplicatedChat.time_since_last_write < 1.hours).should be_true
 
-    # Update the time since hte last write and make sure it updated to the time within the currnet second
-    Chat.update_last_write_time
+    # Update the time since last write. Ensure it updated to the time within the currnet second
+    ReplicatedChat.update_last_write_time
 
     # Time since last write should be less than a second since we just updated it (see line above)
-    unless (Chat.time_since_last_write < 1.second)
+    unless (ReplicatedChat.time_since_last_write < 1.second)
       raise "ERROR!!!!!"
     end
   end

--- a/spec/granite/connection_switching_spec.cr
+++ b/spec/granite/connection_switching_spec.cr
@@ -1,0 +1,17 @@
+require "spec"
+
+describe "Granite::Base track time since last write" do
+  it "should ensure that time since last write to model is saved" do
+    # This is a good way to test last write time
+    # It is unlikely that the test suite takes more than an hour to run
+    (Chat.time_since_last_write < 1.hours).should be_true
+
+    # Update the time since hte last write and make sure it updated to the time within the currnet second
+    Chat.update_last_write_time
+
+    # Time since last write should be less than a second since we just updated it (see line above)
+    unless (Chat.time_since_last_write < 1.second)
+      raise "ERROR!!!!!"
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,6 +10,7 @@ Granite::Connections << Granite::Adapter::Sqlite.new(name: "sqlite", url: ENV["S
 # TODO: Experiment to find a better API.
 Granite::Connections.<<(name: "sqlite_with_replica", writer: ENV["SQLITE_DATABASE_URL"], reader: ENV["SQLITE_REPLICA_URL"], adapter_type: Granite::Adapter::Sqlite)
 Granite::Connections.<<(name: "mysql_with_replica", writer: ENV["MYSQL_DATABASE_URL"], reader: ENV["MYSQL_REPLICA_URL"], adapter_type: Granite::Adapter::Mysql)
+Granite::Connections.<<(name: "pg_with_replica", writer: ENV["PG_DATABASE_URL"], reader: ENV["PG_REPLICA_URL"], adapter_type: Granite::Adapter::Mysql)
 
 require "spec"
 require "../src/granite"
@@ -37,6 +38,6 @@ end
 {% if env("CURRENT_ADAPTER") == "mysql" && !flag?(:issue_473) %}
   Spec.after_each do
     # https://github.com/amberframework/granite/issues/473
-    Granite::Connections["mysql"].try &.database.pool.close
+    Granite::Connections["mysql"].not_nil![:writer].try &.database.pool.close
   end
 {% end %}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ Granite::Connections << Granite::Adapter::Sqlite.new(name: "sqlite", url: ENV["S
 # TODO: Experiment to find a better API.
 Granite::Connections.<<(name: "sqlite_with_replica", writer: ENV["SQLITE_DATABASE_URL"], reader: ENV["SQLITE_REPLICA_URL"], adapter_type: Granite::Adapter::Sqlite)
 Granite::Connections.<<(name: "mysql_with_replica", writer: ENV["MYSQL_DATABASE_URL"], reader: ENV["MYSQL_REPLICA_URL"], adapter_type: Granite::Adapter::Mysql)
-Granite::Connections.<<(name: "pg_with_replica", writer: ENV["PG_DATABASE_URL"], reader: ENV["PG_REPLICA_URL"], adapter_type: Granite::Adapter::Mysql)
+Granite::Connections.<<(name: "pg_with_replica", writer: ENV["PG_DATABASE_URL"], reader: ENV["PG_REPLICA_URL"], adapter_type: Granite::Adapter::Pg)
 
 require "spec"
 require "../src/granite"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -8,7 +8,8 @@ Granite::Connections << Granite::Adapter::Sqlite.new(name: "sqlite", url: ENV["S
 
 # Connections with replicas
 # TODO: Experiment to find a better API.
-Granite::Connections.<<(name: "sqlite_replica", writer: ENV["SQLITE_DATABASE_URL"], reader: ENV["SQLITE_REPLICA_URL"], adapter_type: Granite::Adapter::Sqlite)
+Granite::Connections.<<(name: "sqlite_with_replica", writer: ENV["SQLITE_DATABASE_URL"], reader: ENV["SQLITE_REPLICA_URL"], adapter_type: Granite::Adapter::Sqlite)
+Granite::Connections.<<(name: "mysql_with_replica", writer: ENV["MYSQL_DATABASE_URL"], reader: ENV["MYSQL_REPLICA_URL"], adapter_type: Granite::Adapter::Mysql)
 
 require "spec"
 require "../src/granite"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -9,13 +9,13 @@ ADAPTER_REPLICA_URL = ENV["#{CURRENT_ADAPTER.upcase}_REPLICA_URL"]? || ADAPTER_U
 case CURRENT_ADAPTER
 when "pg"
   Granite::Connections << Granite::Adapter::Pg.new(name: CURRENT_ADAPTER, url: ADAPTER_URL)
-  Granite::Connections.<<(name: "pg_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Pg)
+  Granite::Connections << {name: "pg_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Pg}
 when "mysql"
   Granite::Connections << Granite::Adapter::Mysql.new(name: CURRENT_ADAPTER, url: ADAPTER_URL)
-  Granite::Connections.<<(name: "mysql_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Mysql)
+  Granite::Connections << {name: "mysql_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Mysql}
 when "sqlite"
   Granite::Connections << Granite::Adapter::Sqlite.new(name: CURRENT_ADAPTER, url: ADAPTER_URL)
-  Granite::Connections.<<(name: "sqlite_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Sqlite)
+  Granite::Connections << {name: "sqlite_with_replica", writer: ADAPTER_URL, reader: ADAPTER_REPLICA_URL, adapter_type: Granite::Adapter::Sqlite}
 when Nil
   raise "Please set CURRENT_ADAPTER"
 else

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,6 +6,10 @@ Granite::Connections << Granite::Adapter::Mysql.new(name: "mysql", url: ENV["MYS
 Granite::Connections << Granite::Adapter::Pg.new(name: "pg", url: ENV["PG_DATABASE_URL"])
 Granite::Connections << Granite::Adapter::Sqlite.new(name: "sqlite", url: ENV["SQLITE_DATABASE_URL"])
 
+# Connections with replicas
+# TODO: Experiment to find a better API.
+Granite::Connections.<<(name: "sqlite_replica", writer: ENV["SQLITE_DATABASE_URL"], reader: ENV["SQLITE_REPLICA_URL"], adapter_type: Granite::Adapter::Sqlite)
+
 require "spec"
 require "../src/granite"
 require "../src/adapter/**"

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -8,6 +8,13 @@ end
 {% begin %}
   {% adapter_literal = env("CURRENT_ADAPTER").id %}
 
+  class ReplicatedChat < Granite::Base
+    connection {{ adapter_literal + "_with_replica" }}
+
+    column id : Int64, primary: True
+    column content : String
+  end
+
   class Chat < Granite::Base
     connection {{ adapter_literal }}
     table chats

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -9,9 +9,10 @@ end
   {% adapter_literal = env("CURRENT_ADAPTER").id %}
 
   class ReplicatedChat < Granite::Base
-    connection {{ adapter_literal + "_with_replica" }}
+    connection {{ "#{adapter_literal}_with_replica" }}
+    table replicated_chats
 
-    column id : Int64, primary: True
+    column id : Int64, primary: true
     column content : String
   end
 

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -39,7 +39,7 @@ abstract class Granite::Base
   extend Integrators
   extend Select
 
-  @@last_write_time = Time.utc
+  @@last_write_time = Time.monotonic
 
   def self.last_write_time
     @@last_write_time
@@ -47,7 +47,7 @@ abstract class Granite::Base
 
   # This is done this way because callbacks don't work on class mthods
   def self.update_last_write_time
-    @@last_write_time = Time.utc
+    @@last_write_time = Time.monotonic
   end
 
   def update_last_write_time
@@ -55,7 +55,7 @@ abstract class Granite::Base
   end
 
   def self.time_since_last_write
-    Time.utc - @@last_write_time
+    Time.monotonic - @@last_write_time
   end
 
   def time_since_last_write

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -68,6 +68,10 @@ abstract class Granite::Base
     end
   end
 
+  def switch_to_reader_adapter
+    self.class.switch_to_reader_adapter
+  end
+
   def self.switch_to_writer_adapter
     @@adapter = @@writer_adapter
   end
@@ -79,7 +83,7 @@ abstract class Granite::Base
   def self.schedule_adapter_switch
     spawn do
       sleep 2.seconds
-      self.class.switch_to_reader_adapter
+      switch_to_reader_adapter
     end
   end
 

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -62,6 +62,16 @@ abstract class Granite::Base
     self.class.time_since_last_write
   end
 
+  def self.switch_to_reader_adapter
+    if time_since_last_write > 2.seconds
+      @@adapter = @@reader_adapter
+    end
+  end
+
+  def self.switch_to_writer_adapter
+    @@adapter = @@writer_adapter
+  end
+
   macro inherited
     protected class_getter select_container : Container = Container.new(table_name: table_name, fields: fields)
 

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -39,6 +39,29 @@ abstract class Granite::Base
   extend Integrators
   extend Select
 
+  @@last_write_time = Time.utc
+
+  def self.last_write_time
+    @@last_write_time
+  end
+
+  # This is done this way because callbacks don't work on class mthods
+  def self.update_last_write_time
+    @@last_write_time = Time.utc
+  end
+
+  def update_last_write_time
+    self.class.update_last_write_time
+  end
+
+  def self.time_since_last_write
+    Time.utc - @@last_write_time
+  end
+
+  def time_since_last_write
+    self.class.time_since_last_write
+  end
+
   macro inherited
     protected class_getter select_container : Container = Container.new(table_name: table_name, fields: fields)
 
@@ -70,5 +93,10 @@ abstract class Granite::Base
 
     disable_granite_docs? def initialize
     end
+
+    after_save :update_last_write_time
+    after_update :update_last_write_time
+    after_create :update_last_write_time
+    after_destroy :update_last_write_time
   end
 end

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -72,6 +72,10 @@ abstract class Granite::Base
     @@adapter = @@writer_adapter
   end
 
+  def switch_to_writer_adapter
+    self.switch_to_writer_adapter
+  end
+
   macro inherited
     protected class_getter select_container : Container = Container.new(table_name: table_name, fields: fields)
 
@@ -105,8 +109,6 @@ abstract class Granite::Base
     end
 
     after_save :update_last_write_time
-    after_update :update_last_write_time
-    after_create :update_last_write_time
     after_destroy :update_last_write_time
   end
 end

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -73,7 +73,7 @@ abstract class Granite::Base
   end
 
   def switch_to_writer_adapter
-    self.switch_to_writer_adapter
+    self.class.switch_to_writer_adapter
   end
 
   macro inherited
@@ -108,6 +108,8 @@ abstract class Granite::Base
     disable_granite_docs? def initialize
     end
 
+    before_save :switch_to_writer_adapter
+    before_destroy :switch_to_writer_adapter
     after_save :update_last_write_time
     after_destroy :update_last_write_time
   end

--- a/src/granite/base.cr
+++ b/src/granite/base.cr
@@ -76,6 +76,17 @@ abstract class Granite::Base
     self.class.switch_to_writer_adapter
   end
 
+  def self.schedule_adapter_switch
+    spawn do
+      sleep 2.seconds
+      self.class.switch_to_reader_adapter
+    end
+  end
+
+  def schedule_adapter_switch
+    self.class.schedule_adapter_switch
+  end
+
   macro inherited
     protected class_getter select_container : Container = Container.new(table_name: table_name, fields: fields)
 
@@ -111,6 +122,8 @@ abstract class Granite::Base
     before_save :switch_to_writer_adapter
     before_destroy :switch_to_writer_adapter
     after_save :update_last_write_time
+    after_save :schedule_adapter_switch
     after_destroy :update_last_write_time
+    after_destroy :schedule_adapter_switch
   end
 end

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -1,6 +1,10 @@
 module Granite::ConnectionManagement
   macro included
-    class_property connection_switch_wait_period : Int64 = 2000
+    # Default value for the time a model waits before using a reader
+    # database connection for read operations
+    # all models use this value. Change it
+    # to change it in all Granite::Base models.
+    class_property connection_switch_wait_period : Int64 = Granite::Connections.connection_switch_wait_period
     @@last_write_time = Time.monotonic
     @@current_adapter : Granite::Adapter::Base?
 

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -26,7 +26,7 @@ module Granite::ConnectionManagement
     end
 
     def self.switch_to_reader_adapter
-      if time_since_last_write > 2.seconds
+      if time_since_last_write > @@connection_switch_wait_period.milliseconds
         @@current_adapter = @@reader_adapter
       end
     end
@@ -45,7 +45,7 @@ module Granite::ConnectionManagement
 
     def self.schedule_adapter_switch
       spawn do
-        sleep connection_switch_wait_period.milliseconds
+        sleep @@connection_switch_wait_period.milliseconds
         switch_to_reader_adapter
       end
 

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -1,0 +1,67 @@
+module Granite::ConnectionManagement
+  macro included
+    class_property connection_switch_wait_period : Int64 = 2000
+    @@last_write_time = Time.monotonic
+    @@current_adapter : Granite::Adapter::Base?
+
+    def self.last_write_time
+      @@last_write_time
+    end
+
+    # This is done this way because callbacks don't work on class mthods
+    def self.update_last_write_time
+      @@last_write_time = Time.monotonic
+    end
+
+    def update_last_write_time
+      self.class.update_last_write_time
+    end
+
+    def self.time_since_last_write
+      Time.monotonic - @@last_write_time
+    end
+
+    def time_since_last_write
+      self.class.time_since_last_write
+    end
+
+    def self.switch_to_reader_adapter
+      if time_since_last_write > 2.seconds
+        @@current_adapter = @@reader_adapter
+      end
+    end
+
+    def switch_to_reader_adapter
+      self.class.switch_to_reader_adapter
+    end
+
+    def self.switch_to_writer_adapter
+      @@current_adapter = @@writer_adapter
+    end
+
+    def switch_to_writer_adapter
+      self.class.switch_to_writer_adapter
+    end
+
+    def self.schedule_adapter_switch
+      spawn do
+        sleep connection_switch_wait_period.milliseconds
+        switch_to_reader_adapter
+      end
+
+      Fiber.yield
+    end
+
+    def schedule_adapter_switch
+      self.class.schedule_adapter_switch
+    end
+
+    def self.adapter
+      begin
+        @@current_adapter.not_nil!
+      rescue NilAssertionError
+        Granite::Connections.registered_connections.first?.not_nil![:writer]
+      end
+    end
+  end
+end

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -6,7 +6,10 @@ module Granite::ConnectionManagement
     # to change it in all Granite::Base models.
     class_property connection_switch_wait_period : Int64 = Granite::Connections.connection_switch_wait_period
     @@last_write_time = Time.monotonic
-    @@current_adapter : Granite::Adapter::Base?
+
+    class_property current_adapter : Granite::Adapter::Base?
+    class_property reader_adapter : Granite::Adapter::Base = Granite::Connections.first_reader
+    class_property writer_adapter : Granite::Adapter::Base = Granite::Connections.first_writer
 
     def self.last_write_time
       @@last_write_time
@@ -79,8 +82,8 @@ module Granite::ConnectionManagement
 
     raise error_message if Granite::Connections[{{name}}].nil?
 
-    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
-    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
-    class_getter current_adapter : Granite::Adapter::Base? = @@writer_adapter
+    self.writer_adapter = Granite::Connections[{{name}}].not_nil![:writer]
+    self.reader_adapter = Granite::Connections[{{name}}].not_nil![:reader]
+    self.current_adapter = @@writer_adapter
   end
 end

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -68,4 +68,19 @@ module Granite::ConnectionManagement
       end
     end
   end
+
+  macro connection(name)
+    {% name = name.id.stringify %}
+
+    error_message = "Connection #{{{name}}} not found in Granite::Connections.
+    Available connections are:
+
+    #{Granite::Connections.registered_connections.map{ |conn| "#{conn[:writer].name}"}.join(", ")}"
+
+    raise error_message if Granite::Connections[{{name}}].nil?
+
+    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
+    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
+    class_getter current_adapter : Granite::Adapter::Base? = @@writer_adapter
+  end
 end

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -8,6 +8,13 @@ module Granite
       @@registered_connections << {writer: adapter, reader: adapter}
     end
 
+    # TODO: Find cleaner type restriction method
+    def self.<<(*, name : String, reader : String, writer : String, adapter_type : Granite::Adapter::Base.class) : Nil
+      reader_adapter = adapter_type.new(name: name, url: reader)
+      writer_adapter = adapter_type.new(name: name, url: writer)
+      @@registered_connections << {writer: writer_adapter, reader: reader_adapter}
+    end
+
     # Returns a registered connection with the given *name*, otherwise `nil`.
     def self.[](name : String) : {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}?
       registered_connections.find { |conn| conn[:writer].name == name }

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -9,10 +9,11 @@ module Granite
       @@registered_connections << {writer: adapter, reader: adapter}
     end
 
-    # TODO: Find cleaner type restriction method
-    def self.<<(*, name : String, reader : String, writer : String, adapter_type : Granite::Adapter::Base.class) : Nil
-      reader_adapter = adapter_type.new(name: name, url: reader)
-      writer_adapter = adapter_type.new(name: name, url: writer)
+    def self.<<(data : NamedTuple(name: String, reader: String, writer: String, adapter_type: Granite::Adapter::Base.class)) : Nil
+      raise "Adapter with name '#{data[:name]}' has already been registered." if @@registered_connections.any? { |conn| conn[:writer].name == data[:name] }
+
+      reader_adapter = data[:adapter_type].new(name: data[:name], url: data[:reader])
+      writer_adapter = data[:adapter_type].new(name: data[:name], url: data[:writer])
       @@registered_connections << {writer: writer_adapter, reader: reader_adapter}
     end
 

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -1,16 +1,16 @@
 module Granite
   class Connections
-    class_getter registered_connections = [] of Granite::Adapter::Base
+    class_getter registered_connections = [] of {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}
 
     # Registers the given *adapter*.  Raises if an adapter with the same name has already been registered.
     def self.<<(adapter : Granite::Adapter::Base) : Nil
-      raise "Adapter with name '#{adapter.name}' has already been registered." if @@registered_connections.any? { |conn| conn.name == adapter.name }
-      @@registered_connections << adapter
+      raise "Adapter with name '#{adapter.name}' has already been registered." if @@registered_connections.any? { |conn| conn[:writer].name == adapter.name }
+      @@registered_connections << {writer: adapter, reader: adapter}
     end
 
     # Returns a registered connection with the given *name*, otherwise `nil`.
-    def self.[](name : String) : Granite::Adapter::Base?
-      registered_connections.find { |conn| conn.name == name }
+    def self.[](name : String) : {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}?
+      registered_connections.find { |conn| conn[:writer].name == name }
     end
   end
 end

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -1,5 +1,6 @@
 module Granite
   class Connections
+    class_property connection_switch_wait_period : Int64 = 2000
     class_getter registered_connections = [] of {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}
 
     # Registers the given *adapter*.  Raises if an adapter with the same name has already been registered.

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -20,5 +20,13 @@ module Granite
     def self.[](name : String) : {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}?
       registered_connections.find { |conn| conn[:writer].name == name }
     end
+
+    def self.first_writer
+      @@registered_connections.first?.not_nil![:writer]
+    end
+
+    def self.first_reader
+      @@registered_connections.first?.not_nil![:reader]
+    end
   end
 end

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -223,6 +223,7 @@ class Granite::Query::Builder(Model)
   end
 
   def delete
+    Model.switch_to_writer_adapter
     assembler.delete
   end
 

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -28,13 +28,14 @@ module Granite::Querying
   # that you are using so you are not restricted or dummied down to support a
   # DSL.
   # Lazy load prevent running unnecessary queries from unused variables.
-  def all(clause = "", params = [] of Granite::Columns::Type)
+  def all(clause = "", params = [] of Granite::Columns::Type, use_primary_adapter = true)
+    switch_to_writer_adapter if use_primary_adapter == true
     Collection(self).new(->{ raw_all(clause, params) })
   end
 
   # First adds a `LIMIT 1` clause to the query and returns the first result
   def first(clause = "", params = [] of Granite::Columns::Type)
-    all([clause.strip, "LIMIT 1"].join(" "), params).first?
+    all([clause.strip, "LIMIT 1"].join(" "), params, false).first?
   end
 
   def first!(clause = "", params = [] of Granite::Columns::Type)
@@ -86,7 +87,7 @@ module Granite::Querying
     end
 
     loop do
-      results = all "#{clause} LIMIT ? OFFSET ?", params + [limit, offset]
+      results = all "#{clause} LIMIT ? OFFSET ?", params + [limit, offset], false
       break if results.empty?
       yield results
       offset += limit
@@ -115,14 +116,17 @@ module Granite::Querying
   end
 
   def exec(clause = "")
+    switch_to_writer_adapter
     adapter.open(&.exec(clause))
   end
 
   def query(clause = "", params = [] of Granite::Columns::Type, &block)
+    switch_to_writer_adapter
     adapter.open { |db| yield db.query(clause, args: params) }
   end
 
   def scalar(clause = "", &block)
+    switch_to_writer_adapter
     adapter.open { |db| yield db.scalar(clause) }
   end
 

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -131,7 +131,7 @@ module Granite::Querying
   end
 
   private def exec_exists(clause : String, params : Array(Granite::Columns::Type)) : Bool
-    adapter.exists? quoted_table_name, clause, params
+    self.adapter.exists? quoted_table_name, clause, params
   end
 
   private def build_find_by_clause(criteria : Granite::ModelArgs)

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -57,9 +57,17 @@ module Granite::Tables
 
   # specify the database connection you will be using for this model.
   macro connection(name)
-    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{(name.is_a?(StringLiteral) ? name : name.id.stringify)}}].not_nil![:writer]
-    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{(name.is_a?(StringLiteral) ? name : name.id.stringify)}}].not_nil![:reader]
-    class_getter adapter : Granite::Adapter::Base = @@writer_adapter
+    {% name = name.id.stringify %}
 
+    error_message = "Connection #{{{name}}} not found in Granite::Connections.
+    Available connections are:
+
+    #{Granite::Connections.registered_connections.map{ |conn| "#{conn[:writer].name}"}.join(", ")}"
+
+    raise error_message if Granite::Connections[{{name}}].nil?
+
+    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
+    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
+    class_getter adapter : Granite::Adapter::Base = @@writer_adapter
   end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -10,10 +10,6 @@ end
 
 module Granite::Tables
   module ClassMethods
-    def adapter : Granite::Adapter::Base
-      Granite::Connections.registered_connections.first?.not_nil![:writer] || raise "No connections have been registered."
-    end
-
     def primary_name
       {% begin %}
       {% primary_key = @type.instance_vars.find { |ivar| (ann = ivar.annotation(Granite::Column)) && ann[:primary] } %}
@@ -33,11 +29,11 @@ module Granite::Tables
     end
 
     def quoted_table_name : String
-      adapter.quote(table_name)
+      self.adapter.quote(table_name)
     end
 
     def quote(column_name) : String
-      adapter.quote(column_name)
+      self.adapter.quote(column_name)
     end
 
     # Returns the name of the table for `self`
@@ -66,8 +62,10 @@ module Granite::Tables
 
     raise error_message if Granite::Connections[{{name}}].nil?
 
+
+
     class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
     class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
-    class_getter adapter : Granite::Adapter::Base = @@writer_adapter
+    class_getter current_adapter : Granite::Adapter::Base? = @@writer_adapter
   end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -11,7 +11,7 @@ end
 module Granite::Tables
   module ClassMethods
     def adapter : Granite::Adapter::Base
-      Granite::Connections.registered_connections.first? || raise "No connections have been registered."
+      Granite::Connections.registered_connections.first?.not_nil![:writer] || raise "No connections have been registered."
     end
 
     def primary_name
@@ -57,6 +57,9 @@ module Granite::Tables
 
   # specify the database connection you will be using for this model.
   macro connection(name)
-    class_getter adapter : Granite::Adapter::Base = Granite::Connections[{{(name.is_a?(StringLiteral) ? name : name.id.stringify)}}] || raise "No registered connection with the name '{{name.id}}'"
+    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{(name.is_a?(StringLiteral) ? name : name.id.stringify)}}].not_nil![:writer]
+    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{(name.is_a?(StringLiteral) ? name : name.id.stringify)}}].not_nil![:reader]
+    class_getter adapter : Granite::Adapter::Base = @@writer_adapter
+
   end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -50,21 +50,4 @@ module Granite::Tables
     @[Granite::Table(name: {{(name.is_a?(StringLiteral) ? name : name.id.stringify) || nil}})]
     class ::{{@type.name.id}}; end
   end
-
-  # specify the database connection you will be using for this model.
-  macro connection(name)
-    {% name = name.id.stringify %}
-
-    error_message = "Connection #{{{name}}} not found in Granite::Connections.
-    Available connections are:
-
-    #{Granite::Connections.registered_connections.map{ |conn| "#{conn[:writer].name}"}.join(", ")}"
-
-    raise error_message if Granite::Connections[{{name}}].nil?
-
-
-    class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
-    class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
-    class_getter current_adapter : Granite::Adapter::Base? = @@writer_adapter
-  end
 end

--- a/src/granite/table.cr
+++ b/src/granite/table.cr
@@ -63,7 +63,6 @@ module Granite::Tables
     raise error_message if Granite::Connections[{{name}}].nil?
 
 
-
     class_getter writer_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:writer]
     class_getter reader_adapter : Granite::Adapter::Base = Granite::Connections[{{name}}].not_nil![:reader]
     class_getter current_adapter : Granite::Adapter::Base? = @@writer_adapter


### PR DESCRIPTION
This is the first step in handling #475. The next step is to create a mechanism that lets the adapter know about the reader/writer if they exist and decide which one to run based on the information provided to it.

I however, deem this a good milestone for a PR. This change is large and handling merge conflicts would be a pain. Better to PR it in step by step.