### PR TITLE
Add `skip_timestamps` option

### DIFF
--- a/docker/docker-compose.sqlite.yml
+++ b/docker/docker-compose.sqlite.yml
@@ -1,7 +1,8 @@
 version: '2'
 services:
   spec:
-    command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && sqlite3 --version && crystal spec"'
+    #command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && sqlite3 --version && crystal spec"'
+    command: 'bash -c "cd /app/user && crystal spec"'
     extends:
       file: ../docker-compose.yml
       service: spec

--- a/docker/docker-compose.sqlite.yml
+++ b/docker/docker-compose.sqlite.yml
@@ -1,8 +1,7 @@
 version: '2'
 services:
   spec:
-    #command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && sqlite3 --version && crystal spec"'
-    command: 'bash -c "cd /app/user && crystal spec"'
+    command: 'bash -c "cd /app/user && bin/ameba && crystal tool format --check && sqlite3 --version && crystal spec"'
     extends:
       file: ../docker-compose.yml
       service: spec

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -25,6 +25,20 @@ post.body = "Check this out."
 post.save! # raises when save failed
 ```
 
+To skip the validation callbacks, pass in `validate: false`:
+
+```crystal
+post.save(validate: false)
+post.save!(validate: false)
+```
+
+You can also pass in `skip_timestamps` to save without changing the `updated_at` field on update:
+
+```crystal
+post.save(skip_timestamps: true)
+post.save!(skip_timestamps: true)
+```
+
 ## Read
 
 ### find
@@ -100,6 +114,14 @@ post.update(name: "Granite Really Rocks!") # Assigns attributes and calls save
 
 post = Post.find 1
 post.update!(name: "Granite Really Rocks!") # Assigns attributes and calls save!. Will throw an exception when the save failed
+```
+
+To update a record without changing the `updated_at` field, you can pass in `skip_timestamps`:
+
+```crystal
+post = Post.find 1
+post.update({name: "Granite Really Rocks!"}, skip_timestamps: true)
+post.update!({name: "Granite Really Rocks!"}, skip_timestamps: true)
 ```
 
 ## Delete

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -9,6 +9,12 @@ Post.create(name: "Granite Rocks!", body: "Check this out.") # Set attributes an
 Post.create!(name: "Granite Rocks!", body: "Check this out.") # Set attributes and call save!. Will throw an exception when the save failed
 ```
 
+To create a record without setting the `created_at` & `updated_at` fields, you can pass in `skip_timestamps`.
+
+```crystal
+Post.create({name: "Granite Rocks!", body: "Check this out."}, skip_timestamps: true)
+```
+
 ## Insert
 
 Inserts an already created object into the database.

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -35,6 +35,16 @@ describe "#create" do
       reserved_word.all.should eq("foo")
     end
   end
+
+  context "when skip_timestamps is true" do
+    it "does not update the created_at & updated_at fields" do
+      time = Time.utc(2023, 9, 1)
+      parent = Parent.create({name: "new parent"}, skip_timestamps: true)
+
+      Parent.find!(parent.id).created_at.should be_nil
+      Parent.find!(parent.id).updated_at.should be_nil
+    end
+  end
 end
 
 describe "#create!" do
@@ -47,6 +57,16 @@ describe "#create!" do
   it "does not save but raise an exception" do
     expect_raises(Granite::RecordNotSaved, "Parent") do
       Parent.create!(name: "")
+    end
+  end
+
+  context "when skip_timestamps is true" do
+    it "does not update the created_at & updated_at fields" do
+      time = Time.utc(2023, 9, 1)
+      parent = Parent.create!({name: "new parent"}, skip_timestamps: true)
+
+      Parent.find!(parent.id).created_at.should be_nil
+      Parent.find!(parent.id).updated_at.should be_nil
     end
   end
 end

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -35,15 +35,6 @@ describe "#create" do
       reserved_word.all.should eq("foo")
     end
   end
-
-  describe "when skip_timestamps is true" do
-    it "does not set the created_at and updated_at fields" do
-      parent = Parent.create({name: "New Parent"}, skip_timestamps: true)
-
-      parent.created_at.should eq nil
-      parent.updated_at.should eq nil
-    end
-  end
 end
 
 describe "#create!" do
@@ -56,15 +47,6 @@ describe "#create!" do
   it "does not save but raise an exception" do
     expect_raises(Granite::RecordNotSaved, "Parent") do
       Parent.create!(name: "")
-    end
-  end
-
-  describe "when skip_timestamps is true" do
-    it "does not set the created_at and updated_at fields" do
-      parent = Parent.create!({name: "New Parent"}, skip_timestamps: true)
-
-      parent.created_at.should eq nil
-      parent.updated_at.should eq nil
     end
   end
 end

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -35,6 +35,15 @@ describe "#create" do
       reserved_word.all.should eq("foo")
     end
   end
+
+  describe "when skip_timestamps is true" do
+    it "does not set the created_at and updated_at fields" do
+      parent = Parent.create({name: "New Parent"}, skip_timestamps: true)
+
+      parent.created_at.should eq nil
+      parent.updated_at.should eq nil
+    end
+  end
 end
 
 describe "#create!" do
@@ -47,6 +56,15 @@ describe "#create!" do
   it "does not save but raise an exception" do
     expect_raises(Granite::RecordNotSaved, "Parent") do
       Parent.create!(name: "")
+    end
+  end
+
+  describe "when skip_timestamps is true" do
+    it "does not set the created_at and updated_at fields" do
+      parent = Parent.create!({name: "New Parent"}, skip_timestamps: true)
+
+      parent.created_at.should eq nil
+      parent.updated_at.should eq nil
     end
   end
 end

--- a/spec/granite/transactions/save_spec.cr
+++ b/spec/granite/transactions/save_spec.cr
@@ -35,6 +35,17 @@ describe "#save" do
     model.save.should be_false
   end
 
+  it "does not update timestamps is skip_timestamps is true" do
+    time = Time.utc(2023, 9, 1)
+    parent = Parent.new
+    parent.name = "Test Parent"
+    parent.created_at = time
+    parent.updated_at = time
+    parent.save(skip_timestamps: true)
+    parent.created_at.should eq time
+    parent.updated_at.should eq time
+  end
+
   it "updates an existing object" do
     Parent.clear
     parent = Parent.new

--- a/spec/granite/transactions/update_spec.cr
+++ b/spec/granite/transactions/update_spec.cr
@@ -51,6 +51,17 @@ describe "#update" do
       saved_parent.updated_at.should eq Time.utc.at_beginning_of_second
     end
   end
+
+  context "when skip_timestamps is true" do
+    it "does not update the updated_at field" do
+      time = Time.utc(2023, 9, 1)
+      parent = Parent.create(name: "New Parent")
+      parent.updated_at = time
+      parent.update({name: "Other Parent"}, skip_timestamps: true)
+
+      Parent.find!(parent.id).updated_at.should eq time
+    end
+  end
 end
 
 describe "#update!" do
@@ -73,5 +84,16 @@ describe "#update!" do
     end
 
     Parent.find!(parent.id).name.should eq "New Parent"
+  end
+
+  context "when skip_timestamps is true" do
+    it "does not update the updated_at field" do
+      time = Time.utc(2023, 9, 1)
+      parent = Parent.create(name: "New Parent")
+      parent.updated_at = time
+      parent.update!({name: "Other Parent"}, skip_timestamps: true)
+
+      Parent.find!(parent.id).updated_at.should eq time
+    end
   end
 end

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -10,13 +10,6 @@ module Granite::Transactions
       create(args.to_h)
     end
 
-    def create(args)
-      instance = new
-      instance.set_attributes(args.transform_keys(&.to_s))
-      instance.save
-      instance
-    end
-
     def create(args, skip_timestamps : Bool = false)
       instance = new
       instance.set_attributes(args.to_h.transform_keys(&.to_s))
@@ -26,16 +19,6 @@ module Granite::Transactions
 
     def create!(**args)
       create!(args.to_h)
-    end
-
-    def create!(args)
-      instance = create(args)
-
-      unless instance.errors.empty?
-        raise Granite::RecordNotSaved.new(self.name, instance)
-      end
-
-      instance
     end
 
     def create!(args, skip_timestamps : Bool = false)
@@ -254,12 +237,6 @@ module Granite::Transactions
     update(args.to_h)
   end
 
-  def update(args : Granite::ModelArgs)
-    set_attributes(args.transform_keys(&.to_s))
-
-    save
-  end
-
   def update(args, skip_timestamps : Bool = false)
     set_attributes(args.to_h.transform_keys(&.to_s))
 
@@ -268,12 +245,6 @@ module Granite::Transactions
 
   def update!(**args)
     update!(args.to_h)
-  end
-
-  def update!(args : Granite::ModelArgs)
-    set_attributes(args.transform_keys(&.to_s))
-
-    save!
   end
 
   def update!(args, skip_timestamps : Bool = false)

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -10,10 +10,10 @@ module Granite::Transactions
       create(args.to_h)
     end
 
-    def create(args)
+    def create(args, skip_timestamps : Bool = false)
       instance = new
-      instance.set_attributes(args.transform_keys(&.to_s))
-      instance.save
+      instance.set_attributes(args.to_h.transform_keys(&.to_s))
+      instance.save(skip_timestamps: skip_timestamps)
       instance
     end
 
@@ -21,8 +21,8 @@ module Granite::Transactions
       create!(args.to_h)
     end
 
-    def create!(args)
-      instance = create(args)
+    def create!(args, skip_timestamps : Bool = false)
+      instance = create(args, skip_timestamps)
 
       unless instance.errors.empty?
         raise Granite::RecordNotSaved.new(self.name, instance)
@@ -113,14 +113,14 @@ module Granite::Transactions
     {% end %}
   end
 
-  private def __create
+  private def __create(skip_timestamps : Bool = false)
     {% begin %}
       {% primary_key = @type.instance_vars.find { |ivar| (ann = ivar.annotation(Granite::Column)) && ann[:primary] } %}
       {% raise raise "A primary key must be defined for #{@type.name}." unless primary_key %}
       {% raise "Composite primary keys are not yet supported for '#{@type.name}'." if @type.instance_vars.select { |ivar| ann = ivar.annotation(Granite::Column); ann && ann[:primary] }.size > 1 %}
       {% ann = primary_key.annotation(Granite::Column) %}
 
-      set_timestamps
+      set_timestamps unless skip_timestamps
       fields = self.class.content_fields.dup
       params = content_values
 
@@ -214,7 +214,7 @@ module Granite::Transactions
         __after_update
       else
         __before_create
-        __create
+        __create(skip_timestamps: skip_timestamps)
         __after_create
       end
       __after_save


### PR DESCRIPTION
Resolves #318

This adds the ability to pass `skip_timestamps: true` to `update` and `update!` methods. To do this I had to change the `save` method to accept `skip_timestamps` so to avoid inconsistent behaviour I have also added the option to the `create` and `create!` methods.

To achieve this I had to remove the type definition of `args` on the method definition so that either a `Granite::ModelArgs` or a `NamedTuple` can be passed in with `skip_timestamps`, I originally added another method overload for this case as you can see in the first commit e6f917e4e383d69672a6acb6c5f39c299ef58d13. Open to thoughts on this.

I have also updated the crud.md docs to describe this feature and added a missing example for `save(validate: false)`

