### PR TITLE
refactor: fix linting issues on not_nil! usage

### DIFF
--- a/spec/granite/connection_management_spec.cr
+++ b/spec/granite/connection_management_spec.cr
@@ -6,7 +6,9 @@ describe "Granite::Base track time since last write" do
     ReplicatedChat.new(content: "hello world!").save!
     sleep 500.milliseconds
     current_url = ReplicatedChat.adapter.url
-    reader_url = Granite::Connections[ENV["CURRENT_ADAPTER"] + "_with_replica"].not_nil![:reader].url
+    reader_connection = Granite::Connections["#{ENV["CURRENT_ADAPTER"]}_with_replica"]
+    raise "Reader connection cannot be nil" if reader_connection.nil?
+    reader_url = reader_connection[:reader].url
     current_url.should eq reader_url
   end
 end

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -29,12 +29,16 @@ module Granite
       registered_connections.find { |conn| conn[:writer].name == name }
     end
 
-    def self.first_writer
-      @@registered_connections.first?.not_nil![:writer]
+    def self.first_writer : Granite::Adapter::Base
+      first_connection = @@registered_connections.first?
+      raise "First registered connection cannot be nil" if first_connection.nil?
+      first_connection[:writer]
     end
 
-    def self.first_reader
-      @@registered_connections.first?.not_nil![:reader]
+    def self.first_reader : Granite::Adapter::Base
+      first_connection = @@registered_connections.first?
+      raise "First registered connection cannot be nil" if first_connection.nil?
+      first_connection[:reader]
     end
   end
 end

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -29,15 +29,17 @@ module Granite
       registered_connections.find { |conn| conn[:writer].name == name }
     end
 
-    def self.first_writer : Granite::Adapter::Base
+    def self.first_connection
       first_connection = @@registered_connections.first?
       raise "First registered connection cannot be nil" if first_connection.nil?
+      first_connection
+    end
+
+    def self.first_writer : Granite::Adapter::Base
       first_connection[:writer]
     end
 
     def self.first_reader : Granite::Adapter::Base
-      first_connection = @@registered_connections.first?
-      raise "First registered connection cannot be nil" if first_connection.nil?
       first_connection[:reader]
     end
   end


### PR DESCRIPTION
Currently ameba linting fails due to the usage of not_nil!. This can be fixed by giving the not_nil! an argument of an error message however I've chosen to prioritise readability.