### PR TITLE
Close result set at the end of test in passthrough_spec.cr

### DIFF
--- a/spec/granite/querying/passthrough_spec.cr
+++ b/spec/granite/querying/passthrough_spec.cr
@@ -5,6 +5,7 @@ describe "#query" do
     Parent.clear
     Parent.query "SELECT name FROM parents" do |rs|
       rs.column_name(0).should eq "name"
+      rs.close
     end
   end
 end


### PR DESCRIPTION
This fixes an issue when running against postgres `Expected PQ::Frame::ParseComplete but got PQ::Frame::ReadyForQuery`

The offending spec was: `spec/granite/querying/passthrough_spec.cr` Anything that ran after this spec would throw the above error.

Simply closing the result set before moving on fixed the errors.

Co-authored-by: @jphaward <jphaward@gmail.com>