### PR TITLE
ci: add ameba linting to formatting ci job

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,8 +15,12 @@ jobs:
         uses: oprypin/install-crystal@v1.8.0
         with:
           crystal: latest
+      - name: Install Ameba
+        run: shards install
       - name: Check formatting
         run: crystal tool format --check
+      - name: Check linting
+        run: ./bin/ameba 
   sqlite-spec:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Currently ameba is not in the pipeline however is used when running the tests within Docker (command in the readme). It would be useful for these to be consistent.

I cannot test the pipeline changes locally so it may need tweaking once the workflow has been approved.