### PR TITLE
Fix mysql to allow timestamps null

### DIFF
--- a/spec/granite/migrator/migrator_spec.cr
+++ b/spec/granite/migrator/migrator_spec.cr
@@ -87,7 +87,7 @@ describe Granite::Migrator do
           ,
           `published` BOOL
           ,
-          `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          `created_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
           ) ;\n
           SQL
 

--- a/spec/granite/transactions/create_spec.cr
+++ b/spec/granite/transactions/create_spec.cr
@@ -38,7 +38,6 @@ describe "#create" do
 
   context "when skip_timestamps is true" do
     it "does not update the created_at & updated_at fields" do
-      time = Time.utc(2023, 9, 1)
       parent = Parent.create({name: "new parent"}, skip_timestamps: true)
 
       Parent.find!(parent.id).created_at.should be_nil
@@ -62,7 +61,6 @@ describe "#create!" do
 
   context "when skip_timestamps is true" do
     it "does not update the created_at & updated_at fields" do
-      time = Time.utc(2023, 9, 1)
       parent = Parent.create!({name: "new parent"}, skip_timestamps: true)
 
       Parent.find!(parent.id).created_at.should be_nil

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -12,8 +12,8 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
       "AUTO_UUID"  => "CHAR(36)",
       "Float64"    => "DOUBLE",
       "UUID"       => "CHAR(36)",
-      "created_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
-      "updated_at" => "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+      "created_at" => "TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP",
+      "updated_at" => "TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
     }
   end
 


### PR DESCRIPTION
#486 which was recently merged was failing on the mysql tests for skipping timestamps on create. This is due to mysql not allowing NULL values on timestamps by default - [docs here](https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html)