### PR TITLE
493 upgrade ameba shard to latest version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -27,4 +27,4 @@ development_dependencies:
     version: ~> 0.26.0
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.3.1
+    version: ~> 1.5.0

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -24,7 +24,7 @@ abstract class Granite::Adapter::Base
     @_database ||= DB.open(@url)
   end
 
-  def open(&block)
+  def open(&)
     database.retry do
       database.using_connection do |conn|
         yield conn
@@ -51,7 +51,7 @@ abstract class Granite::Adapter::Base
   # fields (configured using the sql_mapping directive in your model), and an optional
   # raw query string.  The clause and params is the query and params that is passed
   # in via .all() method
-  def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &block)
+  def select(query : Granite::Select::Container, clause = "", params = [] of DB::Any, &)
     clause = ensure_clause_template(clause)
     statement = query.custom ? "#{query.custom} #{clause}" : String.build do |stmt|
       stmt << "SELECT "

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -16,7 +16,7 @@ module Granite
 
       # if reader/writer reference the same db. Make them point to the same granite adapter.
       # This avoids connection pool duplications on the same database.
-      if (data[:reader] == data[:writer])
+      if data[:reader] == data[:writer]
         return @@registered_connections << {writer: writer_adapter, reader: writer_adapter}
       end
 

--- a/src/granite/query/assemblers/base.cr
+++ b/src/granite/query/assemblers/base.cr
@@ -30,7 +30,7 @@ module Granite::Query::Assembler
       [Model.fields].flatten.join ", "
     end
 
-    def build_sql
+    def build_sql(&)
       clauses = [] of String?
       yield clauses
       clauses.compact!.join " "

--- a/src/granite/query/builder.cr
+++ b/src/granite/query/builder.cr
@@ -243,13 +243,13 @@ class Granite::Query::Builder(Model)
     count
   end
 
-  def reject(&block)
+  def reject(&)
     assembler.select.run.reject do |record|
       yield record
     end
   end
 
-  def each(&block)
+  def each(&)
     assembler.select.tap do |record_set|
       record_set.each do |record|
         yield record
@@ -257,7 +257,7 @@ class Granite::Query::Builder(Model)
     end
   end
 
-  def map(&block)
+  def map(&)
     assembler.select.run.map do |record|
       yield record
     end

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -73,7 +73,7 @@ module Granite::Querying
     find_by(criteria) || raise NotFound.new("No #{{{@type.name.stringify}}} found where #{criteria.map { |k, v| %(#{k} #{v.nil? ? "is NULL" : "= #{v}"}) }.join(" and ")}")
   end
 
-  def find_each(clause = "", params = [] of Granite::Columns::Type, batch_size limit = 100, offset = 0)
+  def find_each(clause = "", params = [] of Granite::Columns::Type, batch_size limit = 100, offset = 0, &)
     find_in_batches(clause, params, batch_size: limit, offset: offset) do |batch|
       batch.each do |record|
         yield record
@@ -81,7 +81,7 @@ module Granite::Querying
     end
   end
 
-  def find_in_batches(clause = "", params = [] of Granite::Columns::Type, batch_size limit = 100, offset = 0)
+  def find_in_batches(clause = "", params = [] of Granite::Columns::Type, batch_size limit = 100, offset = 0, &)
     if limit < 1
       raise ArgumentError.new("batch_size must be >= 1")
     end
@@ -120,12 +120,12 @@ module Granite::Querying
     adapter.open(&.exec(clause))
   end
 
-  def query(clause = "", params = [] of Granite::Columns::Type, &block)
+  def query(clause = "", params = [] of Granite::Columns::Type, &)
     switch_to_writer_adapter
     adapter.open { |db| yield db.query(clause, args: params) }
   end
 
-  def scalar(clause = "", &block)
+  def scalar(clause = "", &)
     switch_to_writer_adapter
     adapter.open { |db| yield db.scalar(clause) }
   end


### PR DESCRIPTION
This PR upgrades ameba to v1.50 which fixes the compatibility issues with later versions of Crystal on the post install step.

It also fixes the new linting requirements of v1.5.0.

There are a few linting errors which are not resolved in this PR but are instead covered in #487 and #492.

Once all are merged the ci pipeline *should* be back to green