### PR TITLE
test: fix to_yaml nil value representation for mac

### DIFF
--- a/spec/granite_spec.cr
+++ b/spec/granite_spec.cr
@@ -264,11 +264,8 @@ describe Granite::Base do
     describe "#to_yaml" do
       it "emits nil values when told" do
         t = TodoEmitNull.new(name: "test todo", priority: 20)
-        result = {% if flag?(:darwin) %}
-                   %(---\nid:\nname: test todo\npriority: 20\ncreated_at:\nupdated_at:\n)
-                 {% else %}
-                   %(---\nid: \nname: test todo\npriority: 20\ncreated_at: \nupdated_at: \n)
-                 {% end %}
+        result = %(---\nid: \nname: test todo\npriority: 20\ncreated_at: \nupdated_at: \n)
+
         t.to_yaml.should eq result
       end
 


### PR DESCRIPTION
Fixes #488 where there were previous inconsistencies of yaml across different OS / libraries which are now consistent.