### PR TITLE
Fixed bug preventing Amber from booting

### DIFF
--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -4,12 +4,12 @@ module Granite::ConnectionManagement
     # database connection for read operations
     # all models use this value. Change it
     # to change it in all Granite::Base models.
-    class_property connection_switch_wait_period : Int64 = Granite::Connections.connection_switch_wait_period
+    class_property connection_switch_wait_period : Int32 = Granite::Connections.connection_switch_wait_period
     @@last_write_time = Time.monotonic
 
     class_property current_adapter : Granite::Adapter::Base?
-    class_property reader_adapter : Granite::Adapter::Base = Granite::Connections.first_reader
-    class_property writer_adapter : Granite::Adapter::Base = Granite::Connections.first_writer
+    class_property reader_adapter : Granite::Adapter::Base?
+    class_property writer_adapter : Granite::Adapter::Base?
 
     def self.last_write_time
       @@last_write_time

--- a/src/granite/connections.cr
+++ b/src/granite/connections.cr
@@ -1,6 +1,6 @@
 module Granite
   class Connections
-    class_property connection_switch_wait_period : Int64 = 2000
+    class_property connection_switch_wait_period : Int32 = 2000
     class_getter registered_connections = [] of {writer: Granite::Adapter::Base, reader: Granite::Adapter::Base}
 
     # Registers the given *adapter*.  Raises if an adapter with the same name has already been registered.


### PR DESCRIPTION
- Changed connection period to use less memory by switching to Int32 from Int64 
- Changed reader/writer to allow `nil` now that we have `nil` checks for when the connections are being used. This resolves the issue with Amber not being able to boot.