### PR TITLE
Propagate original callstack, save a fiber allocation if unnecessary

### DIFF
--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -51,6 +51,8 @@ module Granite::ConnectionManagement
     end
 
     def self.schedule_adapter_switch
+      return if @@writer_adapter == @@reader_adapter
+
       spawn do
         sleep @@connection_switch_wait_period.milliseconds
         switch_to_reader_adapter

--- a/src/granite/transactions.cr
+++ b/src/granite/transactions.cr
@@ -68,7 +68,7 @@ module Granite::Transactions
         end
       {% end %}
     rescue err
-      raise DB::Error.new(err.message)
+      raise DB::Error.new(err.message, cause: err)
     end
 
     # Runs an INSERT statement for all records in *model_array*, with options to
@@ -92,7 +92,7 @@ module Granite::Transactions
         end
       {% end %}
     rescue err
-      raise DB::Error.new(err.message)
+      raise DB::Error.new(err.message, cause: err)
     end
 
     def import(model_array : Array(self) | Granite::Collection(self), ignore_on_duplicate : Bool, batch_size : Int32 = model_array.size)
@@ -114,7 +114,7 @@ module Granite::Transactions
         end
       {% end %}
     rescue err
-      raise DB::Error.new(err.message)
+      raise DB::Error.new(err.message, cause: err)
     end
   end
 
@@ -176,7 +176,7 @@ module Granite::Transactions
   rescue err : DB::Error
     raise err
   rescue err
-    raise DB::Error.new(err.message)
+    raise DB::Error.new(err.message, cause: err)
   else
     self.new_record = false
   end
@@ -199,7 +199,7 @@ module Granite::Transactions
     begin
      self.class.adapter.update(self.class.table_name, self.class.primary_name, fields, params)
     rescue err
-      raise DB::Error.new(err.message)
+      raise DB::Error.new(err.message, cause: err)
     end
   {% end %}
   end


### PR DESCRIPTION
I'm working on a project that's generating a couple million rows to enter into a sqlite database. For reasons I haven't figured out yet, I'm getting a "cannot allocate memory" error when a new `spawn` call is being made (I've verified the machine this program is running on has plenty of memory and isn't getting anywhere near the limit, and other fiber allocations seem to be working just fine :shrug: ). Regardless of the what's causing _that_, I was able to update some error propagation in granite to discover an unnecessary `spawn` call being made in the event the `@@reader_adapter` and `@@writer_adapter` are the same adapter. Making this PR to include the error propagation changes as well as fixing the unnecessary `spawn` call.