### PR TITLE
Fix logging of query durations, which were off by 10x for µs precision

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -153,7 +153,7 @@ abstract class Granite::Adapter::Base
     elsif elapsed_time > 0.001
       "#{(elapsed_time * 1_000).trunc}ms".colorize.yellow
     elsif elapsed_time > 0.000_001
-      "#{(elapsed_time * 100_000).trunc}µs".colorize.green
+      "#{(elapsed_time * 1_000_000).trunc}µs".colorize.green
     elsif elapsed_time > 0.000_000_001
       "#{(elapsed_time * 1_000_000_000).trunc}ns".colorize.green
     else


### PR DESCRIPTION
Has been broken since it was originally implemented in 3d73a5de.

Noticed while implementing a similar method in our own code. @Blacksmoke16 is something of this ilk (more readable short span printing) a candidate for stdlib do you think?