### PR TITLE
fix(core): update for crystal 1.20 and fix deprecations

### DIFF
--- a/spec/granite/transactions/touch_spec.cr
+++ b/spec/granite/transactions/touch_spec.cr
@@ -23,7 +23,7 @@ describe "#touch" do
     old_time = Time.utc.at_beginning_of_second
     object = TimeTest.create(test: old_time)
 
-    sleep 3
+    sleep 3.seconds
 
     new_time = Time.utc.at_beginning_of_second
     object.touch
@@ -37,7 +37,7 @@ describe "#touch" do
     old_time = Time.utc.at_beginning_of_second
     object = TimeTest.create(test: old_time)
 
-    sleep 3
+    sleep 3.seconds
 
     new_time = Time.utc.at_beginning_of_second
     object.touch("test")

--- a/src/granite/connection_management.cr
+++ b/src/granite/connection_management.cr
@@ -5,7 +5,7 @@ module Granite::ConnectionManagement
     # all models use this value. Change it
     # to change it in all Granite::Base models.
     class_property connection_switch_wait_period : Int32 = Granite::Connections.connection_switch_wait_period
-    @@last_write_time = Time.monotonic
+    @@last_write_time = Time.instant
 
     class_property current_adapter : Granite::Adapter::Base?
     class_property reader_adapter : Granite::Adapter::Base?
@@ -17,7 +17,7 @@ module Granite::ConnectionManagement
 
     # This is done this way because callbacks don't work on class mthods
     def self.update_last_write_time
-      @@last_write_time = Time.monotonic
+      @@last_write_time = Time.instant
     end
 
     def update_last_write_time
@@ -25,7 +25,7 @@ module Granite::ConnectionManagement
     end
 
     def self.time_since_last_write
-      Time.monotonic - @@last_write_time
+      Time.instant - @@last_write_time
     end
 
     def time_since_last_write

--- a/src/granite/querying.cr
+++ b/src/granite/querying.cr
@@ -31,7 +31,7 @@ module Granite::Querying
     # Lazy load prevent running unnecessary queries from unused variables.
     def all(clause = "", params = [] of Granite::Columns::Type, use_primary_adapter = true)
       switch_to_writer_adapter if use_primary_adapter == true
-      Collection(self).new(->{ raw_all(clause, params) })
+      Collection(self).new(-> { raw_all(clause, params) })
     end
 
     # First adds a `LIMIT 1` clause to the query and returns the first result


### PR DESCRIPTION
fix(core): update for crystal 1.20 and fix deprecations

Hello maintainers!

This PR brings some modernization to the project to fully support Crystal 1.20.
The following updates have been made:
- Fixed a deprecation warning by replacing `Time.monotonic` with `Time.instant`.
- Updated test specs to use `sleep 3.seconds` instead of the deprecated `sleep 3` method.
- Addressed minor formatting issues in `src/granite/querying.cr` to align with the current Crystal formatter.

Tests pass and ameba reports 0 failures.

Please let us know if anything needs further adjustment. 
Rénich directed and tested these changes, with AI assistance in the development process. Thank you for your continued work on Granite!

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
