### PR TITLE
docs(core): add AGENTS.md for AI assistance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AI Agent Guidelines for Granite
+
+Welcome, AI Agents! When contributing to the Granite project, please strictly adhere to the following guidelines to ensure your code integrates seamlessly and maintains the high standards of the Amber framework.
+
+## 1. Language Constraints
+- **This is Crystal, not Ruby.** While Crystal's syntax is inspired by Ruby, it is a distinctly different, statically typed language. Do not use Ruby-isms, `method_missing` magic, or dynamic meta-programming hacks.
+- Crystal is statically typed. Respect the type system and define types explicitly where it improves readability and compilation safety.
+
+## 2. Safety and Types
+- **Avoid unsafe assertions:** Never use `.not_nil!` assertions unless absolutely mathematically certain, and even then, consider alternatives. Use proper type narrowing instead (e.g., `if let`, `.try`, `.as?`, or assigning to a variable within an `if` condition like `if var = nullable_var`).
+
+## 3. Serialization
+- **Use standard serialization:** Do not use the deprecated `yaml_mapping` or `json_mapping` macros. Always use `YAML::Serializable` and `JSON::Serializable` to define serialized models and classes.
+
+## 4. Modern Features
+- **Crystal 1.20+:** Prefer modern Crystal 1.20 features. In particular, leverage features like `M:N` scheduling safe concurrency patterns when writing parallel or concurrent code.
+
+## 5. Development Workflow
+- **Formatting and Linting:** Always run `ameba` to verify linting and formatting before committing any changes. Your code must adhere to the project's formatting standards.
+- **Testing:** Always run `crystal spec` to ensure all tests pass. If you are adding a new feature or fixing a bug, include corresponding specs and guarantee no regressions are introduced.
+
+Thank you for your contributions!


### PR DESCRIPTION
Hello maintainers!

This PR introduces an `AGENTS.md` file to the project root. This file serves as a set of explicit instructions for AI coding assistants (like Gemini, Copilot, or Cursor) to follow when working on the Granite codebase.

It includes key guidelines such as:
- Reminding agents that this is Crystal, not Ruby, to prevent Ruby-isms.
- Enforcing the use of `ameba` and `crystal spec` before committing.
- Discouraging unsafe `.not_nil!` calls in favor of proper type narrowing.
- Encouraging modern Crystal features and standard library serialization (`JSON::Serializable` / `YAML::Serializable`).

These guidelines will help ensure that future AI-assisted contributions meet Granite's quality standards out of the box.

Please let me know if you would like any modifications to these guidelines. Thank you for your time and for maintaining Granite!

Best regards,
Rénich Bon Ćirić
(With assistance from Gemini AI)